### PR TITLE
Ensure proper Spago versions in output

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -4,26 +4,19 @@
 name: "darwin-check"
 
 on:
-  check_suite:
-    types: [completed]
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [macos-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v2
-        with:
-          extra-conf: |
-            substituters = https://cache.garnix.io
-            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
 
       - name: Build purs
         run: nix build .#purs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+.spago

--- a/flake.nix
+++ b/flake.nix
@@ -60,10 +60,12 @@
       pkgs = nixpkgsFor.${system};
       prefix = extractPrefix pkgs.lib;
       package-checks = pkgs.lib.mapAttrs (name: bin:
-        pkgs.runCommand "test-${name}" {buildInputs = [bin];} ''
+        pkgs.runCommand "test-bin" {buildInputs = [bin];} ''
           touch $out
           set -e
-          VERSION=$(${bin}/bin/${prefix name} --version)
+          # Spago writes --version to stderr, oddly enough, so we need to
+          # capture both in the VERSION var.
+          VERSION="$(${bin}/bin/${prefix name} --version 2>&1)"
           EXPECTED_VERSION="${bin.version}"
           echo "$VERSION should match expected output $EXPECTED_VERSION"
           test "$VERSION" = "$EXPECTED_VERSION"

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,6 +1,7 @@
+# Garnix does not yet support x86_64-darwin so that is covered separately in a
+# GitHub Actions workflow file.
 builds:
   exclude: []
   include:
-    - "packages.x86_64-linux.*"
     - "checks.aarch64-darwin.*"
     - "checks.x86_64-linux.*"

--- a/spago/mkSpago.nix
+++ b/spago/mkSpago.nix
@@ -14,62 +14,68 @@
   version,
   rev,
 }: let
-  bundle = stdenv.mkDerivation rec {
-    pname = "spago";
-    inherit version;
-
-    nativeBuildInputs = [purs esbuild nodejs];
-
-    repo = builtins.fetchGit {
-      url = "https://github.com/purescript/spago.git";
-      rev = rev;
-      allRefs = true;
-    };
-
-    src = repo + "/spaghetto";
-
-    buildInfo = writeText "BuildInfo.purs" ''
-      module Spago.Generated.BuildInfo where
-
-      buildInfo =
-        { packages: []
-        , pursVersion: "${purs.version}"
-        , spagoVersion: "${version}"
-        }
-    '';
-
-    entrypoint = writeText "entrypoint.js" ''
-      import { main } from "./output/Main";
-      main();
-    '';
-
-    buildPhase = let
-      npmDependencies = spago-npm-dependencies {inherit src;};
-      workspaces = spago-lock {inherit src;};
-    in ''
-      # Make sure the node_modules folder is available
-      ln -s ${npmDependencies}/js/node_modules .
-
-      set -f
-      ${purs}/bin/purs compile $src/bin/src/**/*.purs ${workspaces.spago-bin.dependencies.globs} ${buildInfo}
-      set +f
-
-      cp ${entrypoint} entrypoint.js
-      esbuild entrypoint.js \
-        --bundle \
-        --minify \
-        --outfile=bundle.js \
-        --platform=node
-    '';
-
-    installPhase = ''
-      mkdir $out
-      cp bundle.js $out
-    '';
-
-    meta.description = "PureScript package manager and build tool";
+  repo = builtins.fetchGit {
+    url = "https://github.com/purescript/spago.git";
+    rev = rev;
+    allRefs = true;
   };
-in
-  writeShellScriptBin "spago" ''
-    ${nodejs}/bin/node ${bundle}/bundle.js "$@"
-  ''
+
+  src = repo + "/spaghetto";
+
+  buildInfo = writeText "BuildInfo.purs" ''
+    module Spago.Generated.BuildInfo where
+
+    buildInfo :: { packages :: Array { name :: String, version :: String }, pursVersion :: String, spagoVersion :: String }
+    buildInfo =
+      { packages: [{ name: "spago", version: "${version}"}, { name: "spago-bin", version: "${version}"}, { name: "spago-core", version: "${version}"}]
+      , pursVersion: "${purs.version}"
+      , spagoVersion: "${version}"
+      }
+  '';
+
+  entrypoint = writeText "entrypoint.js" ''
+    import { main } from "./output/Main";
+    main();
+  '';
+in stdenv.mkDerivation {
+  pname = "spago";
+  version = version;
+  src = src; 
+
+  nativeBuildInputs = [purs esbuild];
+  buildInputs = [nodejs];
+
+  buildPhase = let
+    npmDependencies = spago-npm-dependencies {inherit src;};
+    workspaces = spago-lock {inherit src;};
+  in ''
+    # Make sure the node_modules folder is available
+    ln -s ${npmDependencies}/js/node_modules .
+
+    set -f
+    ${purs}/bin/purs compile $src/bin/src/**/*.purs ${workspaces.spago-bin.dependencies.globs} ${buildInfo}
+    set +f
+
+    cp ${entrypoint} entrypoint.js
+    esbuild entrypoint.js \
+      --bundle \
+      --minify \
+      --outfile=bundle.js \
+      --platform=node
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bundle.js $out/bundle.js
+    cat ${buildInfo} > $out/BuildInfo.purs
+    echo '#!/usr/bin/env sh' > $out/bin/spago
+    echo 'exec ${nodejs}/bin/node '"$out/bundle.js"' "$@"' >> $out/bin/spago
+    chmod +x $out/bin/spago
+  '';
+
+  meta = with lib; {
+    description = "PureScript package manager and build tool";
+    homepage = "https://github.com/purescript/spago";
+    license = licenses.bsd3;
+  };
+}


### PR DESCRIPTION
I thought Spago would pull its version from the `spagoVersion` field in the build info, but it seems to pull it from the workspace packages instead (cc: @f-f).