### PR TITLE
Convert to overlay and fold in spago-nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # PureScript Nix
 
-A flake exposing PureScript tools maintained by the core team (ie. the compiler, `purs`, and package manager, `spago`).
+An overlay and flake exposing PureScript tools maintained by the core team (ie. the compiler, `purs`, and package manager, `spago`). Tested on the following architectures:
+
+- x86_64-linux
+- x86_64-darwin (Intel Mac)
+- aarch64-darwin (M1 Mac)
+
+This Nix library also includes helper functions for building PureScript packages, namely:
+
+- `buildSpagoLock`: Discover and build all workspaces and dependencies from a spago.lock file
+- `buildPackageLock`: Discover and download dependencies listed in a package-lock.json (:warning: only suitable for simple projects like typical PureScript FFI; for significant applications there are better solutions like npmlock2nix)

--- a/build-support/from-yaml.nix
+++ b/build-support/from-yaml.nix
@@ -1,0 +1,173 @@
+# A simple YAML parser written in Nix, suitable for parsing Spago lock files
+# (but NOT suitable for parsing arbitrary YAML).
+#
+# Currently assumes there are no comments in the lockfile.
+#
+# Based on https://github.com/DavHau/fromYaml
+{lib}: let
+  fromYAML = text: let
+    lines = lib.splitString "\n" text;
+
+    # Remove empty lines. If Spago introduces other special lines
+    # (like comments) then this can be expanded.
+    filtered = lib.filter (line: (builtins.match ''[[:space:]]*'' line == null)) lines;
+
+    # Match the following structure for each line:
+    #
+    # {
+    #   isListEntry = bool; # true if elem is part of a list
+    #   indent = int; # indentation level, to represent nesting
+    #   key = string | null;
+    #   value = string | null;
+    # }
+    matchLine = line: let
+      # Single line key value statement
+      singleLine = builtins.match ''([ -]*)(.*): (.*)'' line;
+      # Multi line key value (line contains only key)
+      multiLine = builtins.match ''([ -]*)(.*):$'' line;
+      # Is the line starting a new list element?
+      listEntry = builtins.match ''([[:space:]]*-[[:space:]]+)(.*)'' line;
+    in
+      # Handle list elements (lines starting with ' -')
+      if listEntry != null
+      then rec {
+        isListEntry = true;
+        indent = (builtins.stringLength (builtins.elemAt listEntry 0)) / 2;
+        key =
+          if singleLine != null
+          then builtins.elemAt singleLine 1
+          else null;
+        value =
+          if singleLine != null
+          then builtins.elemAt singleLine 2
+          else builtins.elemAt listEntry 1;
+      }
+      # Handle single line key -> val assignments
+      else if singleLine != null
+      then {
+        isListEntry = false;
+        indent = (builtins.stringLength (builtins.elemAt singleLine 0)) / 2;
+        key = builtins.elemAt singleLine 1;
+        value = builtins.elemAt singleLine 2;
+      }
+      # Handle multi-line key -> object assignment
+      else if multiLine != null
+      then {
+        isListEntry = false;
+        indent = (builtins.stringLength (builtins.elemAt multiLine 0)) / 2;
+        key = builtins.elemAt multiLine 1;
+        value = null;
+      }
+      else null;
+
+    # Extract indent, key, value, isListEntry for each line
+    matched = builtins.map matchLine filtered;
+
+    # Store total number of lines
+    numLines = builtins.length filtered;
+
+    #  Process line by line via a deep recursion, so that this function is
+    #  executed once on each line.
+    #
+    #  It is each iteration's responsibility to traverse through its children
+    #  (for example list elements under a key), and merge/update these correctly
+    #  with itself.
+    #
+    #  By looking at the regex result of the current line and the next line,
+    #  we know what type of structure the current line creates, if it has any
+    #  children, and the the type of the children's structure.
+    processLines = lines: index: let
+      line = builtins.elemAt filtered index;
+
+      nextLine = processLines lines (index + 1);
+
+      match = builtins.elemAt matched index;
+
+      nextMatch = builtins.elemAt matched (index + 1);
+
+      indent =
+        if index == -1
+        then -1
+        else match.indent;
+
+      childrenMustBeList = nextMatch.indent > indent && nextMatch.isListEntry;
+
+      findChildIndices = searchIndex: let
+        matchSearch = builtins.elemAt matched searchIndex;
+      in
+        if searchIndex >= numLines
+        then []
+        else if matchSearch.indent > childIndent
+        then findChildIndices (searchIndex + 1)
+        else if matchSearch.indent == childIndent
+        then
+          if matchSearch.isListEntry == childrenMustBeList
+          then [searchIndex] ++ findChildIndices (searchIndex + 1)
+          else findChildIndices (searchIndex + 1)
+        else [];
+
+      childIndent =
+        if nextMatch.indent > indent
+        then nextMatch.indent
+        else null;
+
+      childIndices =
+        if childIndent == null
+        then []
+        else findChildIndices (index + 1);
+
+      childObjects = builtins.map (processLines lines) childIndices;
+
+      childrenMerged =
+        lib.foldl
+        (all: currentObject: (
+          if builtins.isAttrs currentObject
+          then
+            (
+              if all == null
+              then {}
+              else all
+            )
+            // currentObject
+          else
+            (
+              if all == null
+              then []
+              else all
+            )
+            ++ currentObject
+        ))
+        null
+        childObjects;
+
+      result =
+        if index == (-1)
+        then childrenMerged
+        else if match.isListEntry
+        then
+          # Has key and value -> check if attr continue
+          if match.key != null && match.value != null
+          then
+            # Attrs element follows
+            if match.indent == nextMatch.indent && ! nextMatch.isListEntry
+            then [({"${match.key}" = match.value;} // nextLine)]
+            # List or unindent follows
+            else [{"${match.key}" = match.value;}]
+          # List begin with only a key (child list/attrs follow)
+          else if match.key != null
+          then [{"${match.key}" = childrenMerged;}]
+          # Value only (list elem with plain value)
+          else [match.value]
+        # Not a list entry
+        else
+          # Has key and value
+          if match.key != null && match.value != null
+          then {"${match.key}" = match.value;}
+          # Key only
+          else {"${match.key}" = childrenMerged;};
+    in
+      result;
+  in
+    processLines filtered (-1);
+in
+  fromYAML

--- a/build-support/package-lock.nix
+++ b/build-support/package-lock.nix
@@ -1,0 +1,56 @@
+{
+  fetchurl,
+  writeTextFile,
+  nodejs,
+  stdenv,
+}: {
+  src,
+  package-lock ? src + "/package-lock.json",
+  omit ? [],
+}: let
+  # Read the package-lock.json as a Nix attrset
+  packageLock = builtins.fromJSON (builtins.readFile package-lock);
+
+  omitted = [""] ++ omit;
+
+  # Create an array of all (meaningful) dependencies
+  deps =
+    builtins.attrValues (removeAttrs packageLock.packages omitted)
+    ++ builtins.attrValues (removeAttrs (packageLock.dependencies or {}) omitted);
+
+  # Turn each dependency into a fetchurl call
+  tarballs = builtins.map (entry:
+    fetchurl {
+      url = entry.resolved or (throw "Dependency does not have a 'resolved' key: ${builtins.trace entry ""}");
+      hash = entry.integrity or (throw "Dependency does not have an 'integrity' key: ${builtins.trace entry ""}");
+    })
+  deps;
+
+  # Tarballs to cache
+  lines = (builtins.concatStringsSep "\n" tarballs) + "\n";
+
+  # Write a file with the list of tarballs
+  tarballsFile = writeTextFile {
+    name = "tarballs";
+    text = lines;
+  };
+  version = packageLock.version or "0.0.0";
+in
+  stdenv.mkDerivation {
+    inherit (packageLock) name;
+    inherit src version;
+    buildInputs = [nodejs];
+    buildPhase = ''
+      export HOME=$PWD/.home
+      export npm_config_cache=$PWD/.npm
+      mkdir -p $out/js
+      cd $out/js
+      cp -r $src/. .
+      cat ${tarballsFile} | xargs npm cache add
+      npm ci
+    '';
+
+    installPhase = ''
+      ln -s $out/js/node_modules/.bin $out/bin
+    '';
+  }

--- a/build-support/spago-lock.nix
+++ b/build-support/spago-lock.nix
@@ -1,0 +1,176 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  fetchgit,
+  purescript ? null,
+  # Provided via this repository, not nixpkgs, via the overlay.
+  fromYAML,
+}: {
+  src,
+  spagoYAML ? src + "/spago.yaml",
+  lockYAML ? src + "/spago.lock",
+  purs ? null,
+}: let
+  # The PureScript compiler, used to build packages.
+  compiler =
+    if purs != null
+    then purs
+    else if purescript != null
+    then purescript
+    else throw "No compiler specified.";
+
+  # Helper function for throwing an exception in case a constructed path does
+  # not exist.
+  pathExists = path:
+    if builtins.pathExists path
+    then path
+    else throw "Path does not exist: ${path}";
+
+  # Read the Spago config file
+  config = fromYAML (builtins.readFile spagoYAML);
+
+  # Read the Spago lock file
+  lock = fromYAML (builtins.readFile lockYAML);
+
+  # Read a package listed in the lockfile
+  readLockedPackage = name: attr:
+    if attr.type == "registry"
+    then readRegistryPackage name attr
+    else if attr.type == "git"
+    then readGitPackage name attr
+    else if attr.type == "local"
+    then readLocalPackage name attr
+    else throw "Unknown package type ${attr.type}";
+
+  # Option 1: Fetch and unpack the given package from the registry
+  # "effect": {
+  #   "type": "registry",
+  #   "version": "4.0.0",
+  #   "integrity": "sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M="
+  # },
+  readRegistryPackage = name: attr:
+    stdenv.mkDerivation {
+      name = name;
+      version = attr.version;
+      dependencies =
+        if attr.dependencies == "[]"
+        then []
+        else attr.dependencies;
+
+      src = fetchurl {
+        name = "${name}-${attr.version}.tar.gz";
+        hash = attr.integrity;
+        url = "https://packages.registry.purescript.org/${name}/${attr.version}.tar.gz";
+      };
+
+      installPhase = ''
+        cp -R . "$out"
+      '';
+    };
+
+  # Option 2: Fetch the given package from a Git url. Requires a commit hash.
+  # "console": {
+  #   "type": "git",
+  #   "url": "https://github.com/purescript/purescript-console.git",
+  #   "rev": "3b83d7b792d03872afeea5e62b4f686ab0f09842"
+  # },
+  readGitPackage = name: attr: let
+    fetched = builtins.fetchGit {
+      inherit (attr) url rev;
+      # Look at commit hashes across the repository, not just the default branch,
+      # in case they are pointing to a non-default-branch commit.
+      allRefs = true;
+    };
+  in
+    stdenv.mkDerivation {
+      name = name;
+      dependencies =
+        if attr.dependencies == "[]"
+        then []
+        else attr.dependencies;
+      src =
+        if builtins.hasAttr "subdir" attr
+        then "${fetched}/${attr.subdir}"
+        else fetched;
+      installPhase = ''
+        cp -R . "$out"
+      '';
+    };
+
+  # Option 3: Fetch the given package from a local path
+  # "my-library": {
+  #   "type": "local",
+  #   "path": "my-library"
+  # },
+  readLocalPackage = name: attr:
+    stdenv.mkDerivation {
+      name = name;
+      dependencies =
+        if attr.dependencies == "[]"
+        then []
+        else attr.dependencies;
+      src = pathExists "${src}/${attr.path}";
+      installPhase = ''
+        cp -R . "$out"
+      '';
+    };
+
+  # Read all the locked packages
+  lockedPackages = lib.mapAttrs readLockedPackage lock.packages;
+
+  # Read a workspace package. These are listed at the top of the
+  # lockfile, not in the main packages list.
+  readWorkspacePackage = name: attr:
+    stdenv.mkDerivation {
+      name = name;
+      # The workspace packages list version ranges with their dependencies, so
+      # we want to take only the keys.
+      dependencies =
+        if attr.dependencies == "[]"
+        then []
+        else let
+          toNames = dep:
+            if builtins.typeOf dep == "set"
+            then lib.attrNames dep
+            else [dep];
+        in
+          lib.concatMap toNames attr.dependencies;
+      src =
+        if attr.path == "./"
+        then src
+        else pathExists "${src}/${attr.path}";
+      installPhase = ''
+        cp -R . $out
+      '';
+    };
+
+  # Read the workspace packages
+  workspacePackages = lib.mapAttrs readWorkspacePackage lock.workspace.packages;
+
+  # Union all packages so they can be used as a little package database
+  allPackages = lockedPackages // workspacePackages;
+
+  closure = name: {
+    key = name;
+    package = allPackages.${name} or (builtins.throw ''Missing package "${name}"'');
+  };
+
+  workspaceClosure = workspace:
+    builtins.genericClosure {
+      startSet = map closure workspace.dependencies;
+      operator = entry: map closure entry.package.dependencies;
+    };
+
+  buildWorkspace = name: drv: {
+    dependencies = rec {
+      # Get all dependencies of the workspace
+      sources = map (pkg: pkg.package) (workspaceClosure drv);
+      # Turn them into glob patterns acceptable for the compiler
+      globs = builtins.concatStringsSep " " (map (path: "'${path}/src/**/*.purs'") sources);
+    };
+  };
+
+  workspaces = lib.mapAttrs buildWorkspace workspacePackages;
+in
+  workspaces

--- a/flake.lock
+++ b/flake.lock
@@ -2,39 +2,23 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685399834,
-        "narHash": "sha256-Lt7//5snriXSdJo5hlVcDkpERL1piiih0UXIz1RUcC4=",
+        "lastModified": 1685716800,
+        "narHash": "sha256-b6RpYRRsv6Wwl9XG2sjLvqKdkPMvqQqgtiGJHAIyGSw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "58c85835512b0db938600b6fe13cc3e3dc4b364e",
+        "rev": "f3d743463920751eb092930d06e700981398332a",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "master",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "spago-nix": "spago-nix"
-      }
-    },
-    "spago-nix": {
-      "locked": {
-        "lastModified": 1685401988,
-        "narHash": "sha256-ErtsGoCUyqLsfFhSOUFX/8ZU20nayPmUZ8wDm0j9tEg=",
-        "owner": "thomashoneyman",
-        "repo": "spago-nix",
-        "rev": "13d7a29c3fd144f2a8e64b53785c70f99ed73413",
-        "type": "github"
-      },
-      "original": {
-        "owner": "thomashoneyman",
-        "repo": "spago-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,13 @@
+final: prev: let
+  fromYAML = prev.callPackage ./build-support/from-yaml.nix {};
+in rec {
+  # PureScript tools
+  purs = prev.callPackages ./purs/versions.nix {};
+  spago = prev.callPackages ./spago/versions.nix {compilers = purs;};
+
+  # Utilities for building PureScript packages
+  buildPackageLock = prev.callPackage ./build-support/package-lock.nix {};
+  buildSpagoLock = prev.callPackage ./build-support/spago-lock.nix {
+    inherit fromYAML;
+  };
+}

--- a/purs/mkPurs.nix
+++ b/purs/mkPurs.nix
@@ -36,5 +36,8 @@ in
       $PURS --bash-completion-script $PURS > $out/etc/bash_completion.d/purs-completion.bash
     '';
 
-    meta.description = "A strongly-typed functional programming language that compiles to JavaScript";
+    meta = with lib; {
+      description = "Compiler for a strongly-typed language that compiles to JavaScript";
+      homepage = "https://github.com/purescript/purescript";
+    };
   }

--- a/spago/mkSpago.nix
+++ b/spago/mkSpago.nix
@@ -5,9 +5,9 @@
   esbuild,
   nodejs,
   writeShellScriptBin,
-  # via spago-nix overlay
-  spago-lock,
-  spago-npm-dependencies,
+  # via overlay
+  buildSpagoLock,
+  buildPackageLock,
   # specific version provided via flake
   purs,
   # required additional arguments
@@ -46,8 +46,8 @@ in stdenv.mkDerivation {
   buildInputs = [nodejs];
 
   buildPhase = let
-    npmDependencies = spago-npm-dependencies {inherit src;};
-    workspaces = spago-lock {inherit src;};
+    npmDependencies = buildPackageLock {inherit src;};
+    workspaces = buildSpagoLock {inherit src;};
   in ''
     # Make sure the node_modules folder is available
     ln -s ${npmDependencies}/js/node_modules .


### PR DESCRIPTION
Adds an overlay to the repo, which is used and re-exported by the flake. Replaces the dependency on spago-nix so everything's in a single repository. Updates the README to describe the functions provided by the repo.