### PR TITLE
Allow generation script to fetch tools independently

### DIFF
--- a/generate/bin/src/Main.purs
+++ b/generate/bin/src/Main.purs
@@ -160,6 +160,7 @@ main = Aff.launchAff_ do
           Console.log $ "New spago releases: " <> Utils.printJson Nix.Manifest.spagoManifestCodec spagoUpdates
         else Console.log "No new spago releases."
 
+    -- TODO: Also update the named manifest file.
     Update dir commit -> do
       let envFile = Path.concat [ dir, "..", "generate", ".env" ]
       Console.log $ "Loading .env file from " <> envFile
@@ -172,6 +173,7 @@ main = Aff.launchAff_ do
           Env.lookupOptional Env.githubToken >>= case _ of
             Nothing -> Octokit.newOctokit
             Just tok -> Octokit.newAuthOctokit tok
+
       AppM.runAppM { octokit, manifestDir: dir, gitBranch: branch, tmpDir: tmp } do
         pursManifest <- readPursManifest
         pursUpdates <- fetchPursReleases (Set.unions $ map Map.keys $ Map.values pursManifest)

--- a/generate/bin/src/Main.purs
+++ b/generate/bin/src/Main.purs
@@ -56,6 +56,11 @@ data Commit = DoCommit | NoCommit
 
 derive instance Eq Commit
 
+-- TODO: Allow specifying one or more specific tools to include (default to all).
+-- Make the manifest dir optional (default: use git rev-parse to go to the root,
+-- look for a "manifests" directory containing "purs.json" and "spago.json").
+--
+-- Then, commands mean "verify <tool> using <dir>" or "update <tool>"
 data Command
   = Verify FilePath
   | Prefetch FilePath
@@ -380,6 +385,9 @@ pursReleaseToManifest existing release = do
 
 -- TODO: Spago's alpha does not currently have any official releases, so we
 -- don't fetch anything.
+--
+-- TODO: Actually, fetch the releases, and decide based on the tag whether to
+-- use the fetchurl approach or use the git rev approach.
 fetchSpagoReleases :: AppM SpagoManifest
 fetchSpagoReleases = do
   Console.log "Fetching spago releases..."

--- a/generate/lib/src/Tool.purs
+++ b/generate/lib/src/Tool.purs
@@ -1,0 +1,54 @@
+module Lib.Tool where
+
+import Prelude
+
+import Data.Bounded.Generic (genericBottom, genericTop)
+import Data.Either (Either(..))
+import Data.Enum (class BoundedEnum, class Enum, enumFromTo)
+import Data.Enum.Generic (genericCardinality, genericFromEnum, genericPred, genericSucc, genericToEnum)
+import Data.Generic.Rep (class Generic)
+
+-- | A tool that can be used to build a PureScript project.
+data Tool
+  = Purs
+  | Spago
+  | PursTidy
+  | PursBackendEs
+
+derive instance Eq Tool
+derive instance Ord Tool
+derive instance Generic Tool _
+
+instance Enum Tool where
+  pred = genericPred
+  succ = genericSucc
+
+instance Bounded Tool where
+  bottom = genericBottom
+  top = genericTop
+
+instance BoundedEnum Tool where
+  cardinality = genericCardinality
+  toEnum = genericToEnum
+  fromEnum = genericFromEnum
+
+-- | Print a tool as its executable name
+print :: Tool -> String
+print = case _ of
+  Purs -> "purs"
+  Spago -> "spago"
+  PursTidy -> "purs-tidy"
+  PursBackendEs -> "purs-backend-es"
+
+-- | Parse a tool from its executable name
+parse :: String -> Either String Tool
+parse = case _ of
+  "purs" -> Right Purs
+  "spago" -> Right Spago
+  "purs-tidy" -> Right PursTidy
+  "purs-backend-es" -> Right PursBackendEs
+  other -> Left $ "Unknown tool: " <> other
+
+-- | All tools supported by the library.
+all :: Array Tool
+all = enumFromTo bottom top

--- a/generate/spago.lock
+++ b/generate/spago.lock
@@ -920,7 +920,7 @@ packages:
   registry-lib:
     type: git
     url: https://github.com/purescript/registry-dev.git
-    rev: 01e2067b54f0bf6c0c22d50a142c2abfabf4c7b5
+    rev: d45cdca59a572889db03cf6ea689c6b41808e855
     subdir: lib
     dependencies:
       - aff

--- a/manifests/default.nix
+++ b/manifests/default.nix
@@ -1,6 +1,7 @@
 # This derivation exposes all the tools described by the manifests in this
 # directory.
 {
+  lib,
   callPackage,
   callPackages,
 }: let
@@ -15,12 +16,18 @@
   # The 'named.json' file records what packages should be mapped to the default
   # package names. This is the latest stable or unstable version for each package.
   namedPackages =
-    builtins.mapAttrs
+    lib.mapAttrs'
     (
       name: value: let
-        bin-name = "${builtins.replaceStrings ["-unstable"] [""] name}-bin";
-      in
-        packages.${bin-name}.${value}
+        # We strip the 'stable' suffix from package names to get the default
+        # package name.
+        pkg-name = builtins.replaceStrings ["-stable"] [""] name;
+        # The bin name is the default package name with '-bin' appended.
+        bin-name = "${builtins.replaceStrings ["-stable" "-unstable"] ["" ""] name}-bin";
+      in {
+        name = pkg-name;
+        value = packages.${bin-name}.${value};
+      }
     )
     (builtins.fromJSON (builtins.readFile ./named.json));
 in

--- a/manifests/named.json
+++ b/manifests/named.json
@@ -1,5 +1,5 @@
 {
-  "purs": "purs-0_15_9",
+  "purs-stable": "purs-0_15_9",
   "purs-unstable": "purs-0_15_10-0",
-  "spago": "spago-0_93_5"
+  "spago-stable": "spago-0_93_5"
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -2,7 +2,7 @@ final: prev: let
   fromYAML = prev.callPackage ./nix/from-yaml.nix {};
 
   # All of the tools supported by this repo
-  tooling = import ./manifests {inherit (prev) callPackage callPackages;};
+  tooling = import ./manifests {inherit (prev) lib callPackage callPackages;};
 
   # All of the library functions supported by this repo
   buildPackageLock = prev.callPackage ./nix/package-lock.nix {};

--- a/overlay.nix
+++ b/overlay.nix
@@ -7,10 +7,11 @@ final: prev: let
   # All of the library functions supported by this repo
   buildPackageLock = prev.callPackage ./nix/package-lock.nix {};
   buildSpagoLock = prev.callPackage ./nix/spago-lock.nix {inherit fromYAML;};
+
   purix = {
     lib = buildPackageLock // buildSpagoLock;
     buildPackageLock = buildPackageLock.buildPackageLock;
     buildSpagoLock = buildSpagoLock.workspaces;
   };
 in
-  {inherit purix;} // tooling
+  {purix = purix;} // tooling


### PR DESCRIPTION
This PR defines independent tool types rather than a record of all supported tools, in anticipation of future work to support `purs-tidy` and `purs-backend-es` and Haskell versions of `spago`, which are going to require special handling.