### PR TITLE
Use NPM tarballs for Spago

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
             echo "$VERSION should match expected output $EXPECTED_VERSION"
             test "$VERSION" = "$EXPECTED_VERSION"
           '')
-        # TODO: Remove once spago is stable in the PureScript build.
+        # TODO: Remove once the purescript build of spago is stable
         (pkgs.lib.filterAttrs (k: v: !(k == "spago" && system == "aarch64-darwin")) self.packages.${system});
 
       example-checks = pkgs.callPackages ./nix/examples {};

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
           pkgs.runCommand "test-${name}-${version}" {} ''
             touch $out
             set -e
+            set -x
 
             # Some package versions are not supported on some systems, ie. the
             # "stable" version of Spago is not supported on aarch64.
@@ -96,6 +97,7 @@
           pkgs.runCommand "test-generate" {} ''
             mkdir -p $out/bin
             set -e
+            set -x
             cp ${bin}/bin/${bin.name} $out/bin/test-generate
             ${bin}/bin/${bin.name} verify ${manifests}
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,12 @@
     in {
       default = pkgs.mkShell {
         name = "purescript-nix";
-        buildInputs = [self.packages.${system}.spago-unstable self.packages.${system}.purs-unstable];
+        buildInputs = [
+          self.packages.${system}.spago-unstable
+          self.packages.${system}.purs-unstable
+          pkgs.prefetch-npm-deps
+          pkgs.nix-prefetch-git
+        ];
       };
     });
   };

--- a/generate/lib/src/SemVer.purs
+++ b/generate/lib/src/SemVer.purs
@@ -6,19 +6,21 @@ import Data.Argonaut.Core as Argonaut
 import Data.Bifunctor (lmap)
 import Data.Codec.Argonaut (JsonCodec)
 import Data.Codec.Argonaut as CA
-import Registry.Internal.Codec as Registry.Codec
 import Data.Either (Either(..), note)
 import Data.Either as Either
 import Data.Int as Int
 import Data.Map (Map)
 import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (class Newtype)
 import Data.String as String
+import Registry.Internal.Codec as Registry.Codec
 import Registry.Version (Version)
 import Registry.Version as Version
 import Safe.Coerce (coerce)
 
 newtype SemVer = SemVer { version :: Version, pre :: Maybe Int }
 
+derive instance Newtype SemVer _
 derive instance Eq SemVer
 
 instance Ord SemVer where

--- a/generate/lib/test/Test/Lib/Manifest.purs
+++ b/generate/lib/test/Test/Lib/Manifest.purs
@@ -6,6 +6,7 @@ import Control.Alt ((<|>))
 import Data.Array as Array
 import Data.Codec.Argonaut (JsonCodec)
 import Data.Codec.Argonaut as CA
+import Data.Either (Either(..))
 import Data.String as String
 import Data.Traversable (for)
 import Lib.Nix.Manifest (NamedManifest, PursManifest, SpagoManifest, namedManifestCodec, pursManifestCodec, spagoManifestCodec)
@@ -46,3 +47,4 @@ nixManifestCodec = CA.codec' decode encode
     map SpagoManifest (CA.decode spagoManifestCodec json)
       <|> map PursManifest (CA.decode pursManifestCodec json)
       <|> map NamedManifest (CA.decode namedManifestCodec json)
+      <|> Left (CA.TypeMismatch "Expected a SpagoManifest, PursManifest, or NamedManifest")

--- a/manifests/build-support/mkSpagoDerivation.nix
+++ b/manifests/build-support/mkSpagoDerivation.nix
@@ -1,84 +1,37 @@
 {
-  stdenv,
   lib,
-  writeText,
-  esbuild,
-  nodejs,
-  writeShellScriptBin,
-  # via overlay
-  purix,
-  purs-bin,
+  stdenv,
+  fetchurl,
 }: {
   version,
-  rev,
-}: let
-  purs = purs-bin.purs-0_15_9; # TODO: Discover this from the lockfile or manifest?
+  url,
+  hash,
+}:
+stdenv.mkDerivation rec {
+  pname = "spago";
+  inherit version;
 
-  repo = builtins.fetchGit {
-    inherit rev;
-    url = "https://github.com/purescript/spago.git";
-    allRefs = true;
+  src = fetchurl {inherit url hash;};
+
+  buildPhase = ''
+    tar xf $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    mv package/bin/bundle.js $out/bin/bundle.js
+    mv package/package.json $out/package.json
+
+    chmod +x $out/bin/bundle.js
+    patchShebangs $out/bin/bundle.js
+
+    ln -s $out/bin/bundle.js $out/bin/spago
+  '';
+
+  meta = with lib; {
+    description = "PureScript package manager and build tool";
+    homepage = "https://github.com/purescript/spago";
+    license = licenses.bsd3;
   };
-
-  src = repo + "/spaghetto";
-
-  buildInfo = writeText "BuildInfo.purs" ''
-    module Spago.Generated.BuildInfo where
-
-    buildInfo :: { packages :: Array { name :: String, version :: String }, pursVersion :: String, spagoVersion :: String }
-    buildInfo =
-      { packages: [{ name: "spago", version: "${version}"}, { name: "spago-bin", version: "${version}"}, { name: "spago-core", version: "${version}"}]
-      , pursVersion: "${purs.version}"
-      , spagoVersion: "${version}"
-      }
-  '';
-
-  entrypoint = writeText "entrypoint.js" ''
-    import { main } from "./output/Main";
-    main();
-  '';
-in
-  stdenv.mkDerivation {
-    pname = "spago";
-    inherit version src;
-
-    nativeBuildInputs = [purs esbuild];
-    buildInputs = [nodejs];
-
-    buildPhase = let
-      npmDependencies = purix.buildPackageLock {src = src;};
-      workspaces = purix.buildSpagoLock {
-        src = src;
-        lockfile = src + "/spago.lock";
-      };
-    in ''
-      # Make sure the node_modules folder is available
-      ln -s ${npmDependencies}/js/node_modules .
-
-      set -f
-      ${purs}/bin/purs compile $src/bin/src/**/*.purs ${workspaces.spago-bin.dependencies.globs} ${buildInfo}
-      set +f
-
-      cp ${entrypoint} entrypoint.js
-      esbuild entrypoint.js \
-        --bundle \
-        --minify \
-        --outfile=bundle.js \
-        --platform=node
-    '';
-
-    installPhase = ''
-      mkdir -p $out/bin
-      cp bundle.js $out/bundle.js
-      cat ${buildInfo} > $out/BuildInfo.purs
-      echo '#!/usr/bin/env sh' > $out/bin/spago
-      echo 'exec ${nodejs}/bin/node '"$out/bundle.js"' "$@"' >> $out/bin/spago
-      chmod +x $out/bin/spago
-    '';
-
-    meta = with lib; {
-      description = "PureScript package manager and build tool";
-      homepage = "https://github.com/purescript/spago";
-      license = licenses.bsd3;
-    };
-  }
+}

--- a/manifests/build-support/mkSpagoDerivation.nix
+++ b/manifests/build-support/mkSpagoDerivation.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  nodejs,
 }: {
   version,
   url,
@@ -12,6 +13,8 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {inherit url hash;};
+
+  nativeBuildInputs = [nodejs];
 
   buildPhase = ''
     tar xf $src

--- a/manifests/default.nix
+++ b/manifests/default.nix
@@ -37,10 +37,14 @@
       acc: version: let
         name = "spago-${builtins.replaceStrings ["."] ["_"] version}";
         legacyEntry = entries.${version}.${system} or {};
+        entry = entries.${version};
       in
-        if legacyEntry != {}
+        # To accommodate systems that don't work for legacy spago versions
+        if legacyEntry == {} && !(builtins.hasAttr "url" entry)
+        then acc
+        else if legacyEntry != {}
         then acc // {${name} = mkLegacySpagoDerivation ({inherit version;} // legacyEntry);}
-        else acc // {${name} = mkSpagoDerivation ({inherit version;} // entries.${version});}
+        else acc // {${name} = mkSpagoDerivation ({inherit version;} // entry);}
     ) {}
     (builtins.attrNames entries);
 

--- a/manifests/default.nix
+++ b/manifests/default.nix
@@ -36,13 +36,11 @@
     (
       acc: version: let
         name = "spago-${builtins.replaceStrings ["."] ["_"] version}";
-        entry = entries.${version}.${system} or entries.${version}.rev or {};
+        legacyEntry = entries.${version}.${system} or {};
       in
-        if builtins.typeOf entry == "string"
-        then acc // {${name} = mkSpagoDerivation ({inherit version;} // {rev = entry;});}
-        else if entry != {}
-        then acc // {${name} = mkLegacySpagoDerivation ({inherit version;} // entry);}
-        else acc
+        if legacyEntry != {}
+        then acc // {${name} = mkLegacySpagoDerivation ({inherit version;} // legacyEntry);}
+        else acc // {${name} = mkSpagoDerivation ({inherit version;} // entries.${version});}
     ) {}
     (builtins.attrNames entries);
 

--- a/manifests/spago.json
+++ b/manifests/spago.json
@@ -150,6 +150,7 @@
     }
   },
   "0.93.5": {
-    "rev": "7721861d059ffc903da686eca99e74e5a268e1b9"
+    "hash": "sha256-Wyma1OzF6I80JPhso581qeNsExxpp7qUO4Mk/nuVJ4Y=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.5.tgz"
   }
 }


### PR DESCRIPTION
It's a bit of a bummer to have to compile Spago from source when using the NPM-produced bundle and entering a development shell. This uses the tarball from NPM directly instead (we can always support compile-from-source + bundle later, if something doesn't happen to make it to NPM).