### PR TITLE
Support incremental PureScript builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 result
+output
 
 .spago
 .psc*

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686660328,
-        "narHash": "sha256-l3OeGnWAMig1FckVOtIlqC6ei8gduHsZtQ7I1GHjZFc=",
+        "lastModified": 1687093939,
+        "narHash": "sha256-zw9ztAI3G7ayjRFK9G18yiy4NceLZMF6QKWZC+eyWs0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61b277bd3a2449b8a4e79034616c867a862b3b99",
+        "rev": "572d26930456132e7f2035340e3d88b36a5e9b6e",
         "type": "github"
       },
       "original": {

--- a/generate/bin/src/Main.purs
+++ b/generate/bin/src/Main.purs
@@ -227,5 +227,5 @@ main = Aff.launchAff_ do
                     Console.log $ Octokit.printGitHubError error
                     liftEffect (Process.exit 1)
                   Right { url } -> do
-                    Console.log "Successfully created pull request!"
+                    Console.log "Successfully created pull request."
                     Console.log url

--- a/generate/bin/src/Run.purs
+++ b/generate/bin/src/Run.purs
@@ -21,7 +21,6 @@ import Data.String as String
 import Data.Traversable (foldMap, for)
 import Data.TraversableWithIndex (forWithIndex)
 import Data.Tuple (Tuple(..))
-import Debug (traceM)
 import Effect.Class (liftEffect)
 import Effect.Class.Console as Console
 import Lib.Foreign.Octokit (Release, ReleaseAsset)

--- a/generate/default.nix
+++ b/generate/default.nix
@@ -9,10 +9,7 @@
   purs-backend-es,
 }: let
   npmDependencies = purix.lib.buildPackageLock {src = ./.;};
-  workspaces = purix.lib.workspaces {
-    src = ./.;
-    lockfile = ./. + "/spago.lock";
-  };
+  packages = purix.lib.buildSpagoLock {src = ./.;};
   entrypoint = writeText "entrypoint.js" ''
     import { main } from "./output-es/Bin.Main";
     main();
@@ -24,9 +21,11 @@ in
     nativeBuildInputs = [purs purs-backend-es esbuild];
     buildPhase = ''
       ln -s ${npmDependencies}/js/node_modules .
+      ln -s ${packages.${name}}/output .
       set -f
-      purs compile $src/${name}/**/*.purs ${workspaces.${name}.dependencies.globs} --codegen corefn
       purs-backend-es build
+      ls output-es
+      ls output-es/Bin.Main
       set +f
       cp ${entrypoint} entrypoint.js
       esbuild entrypoint.js \

--- a/generate/spago.lock
+++ b/generate/spago.lock
@@ -929,7 +929,7 @@ packages:
   registry-lib:
     type: git
     url: https://github.com/purescript/registry-dev.git
-    rev: d45cdca59a572889db03cf6ea689c6b41808e855
+    rev: 3d6457290b32696d85ab4a328b26fb1943602038
     subdir: lib
     dependencies:
       - aff

--- a/nix/examples/simple-ffi/default.nix
+++ b/nix/examples/simple-ffi/default.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   purix,
+  purs-bin,
 }: let
   packageLock = purix.buildPackageLock {src = ./.;};
   spagoLock = purix.buildSpagoLock {
@@ -11,12 +12,13 @@ in
   stdenv.mkDerivation {
     name = "bin";
     src = ./.;
+    nativeBuildInputs = [purs-bin.purs-0_15_9];
     buildPhase = ''
+      echo "Linking ..."
       ln -s ${packageLock}/js/node_modules .
-      echo ${spagoLock.simple.dependencies.globs}
-      touch $out
+      ln -s ${spagoLock.simple}/output .
     '';
     installPhase = ''
-      touch $out
+      ls output > $out
     '';
   }

--- a/nix/examples/simple-ffi/src/Main.purs
+++ b/nix/examples/simple-ffi/src/Main.purs
@@ -1,0 +1,1 @@
+module SimpleFFI.Main where

--- a/nix/examples/simple/default.nix
+++ b/nix/examples/simple/default.nix
@@ -11,10 +11,11 @@ in
     name = "bin";
     src = ./.;
     buildPhase = ''
-      echo ${lock.simple.dependencies.globs}
-      touch $out
+      echo "Linking ..."
+      ln -s ${lock.simple}/output .
     '';
     installPhase = ''
-      touch $out
+      mkdir -p $out
+      cp -r output $out
     '';
   }

--- a/nix/examples/simple/spago.lock
+++ b/nix/examples/simple/spago.lock
@@ -6,6 +6,7 @@ workspace:
         - console
         - effect
         - prelude
+        - newtype
       test_dependencies: []
 packages:
   console:
@@ -25,4 +26,22 @@ packages:
     type: registry
     version: 6.0.1
     integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
+    dependencies: []
+  newtype:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
+    dependencies:
+      - prelude
+      - safe-coerce
+  safe-coerce:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
+    dependencies:
+      - unsafe-coerce
+  unsafe-coerce:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
     dependencies: []

--- a/nix/examples/simple/spago.yaml
+++ b/nix/examples/simple/spago.yaml
@@ -4,6 +4,7 @@ package:
     - console
     - effect
     - prelude
+    - newtype
   test:
     dependencies: []
     main: Test.Main

--- a/nix/examples/simple/src/Main.purs
+++ b/nix/examples/simple/src/Main.purs
@@ -1,0 +1,1 @@
+module Example.Simple.Main where

--- a/nix/spago-lock.nix
+++ b/nix/spago-lock.nix
@@ -3,8 +3,11 @@
   lib,
   fetchurl,
   fetchgit,
+  jq,
+  writeShellScript,
   # The following are present via the overlay
   fromYAML,
+  purs-bin,
 }: rec {
   # Helper function for throwing an exception in case a constructed path does
   # not exist.
@@ -20,13 +23,13 @@
   readSpagoLock = lockfile: fromYAML (builtins.readFile lockfile);
 
   # Read a package listed in the lockfile
-  readLockedPackage = name: attr:
+  readLockedPackage = src: name: attr:
     if attr.type == "registry"
     then readRegistryPackage name attr
     else if attr.type == "git"
     then readGitPackage name attr
     else if attr.type == "local"
-    then readLocalPackage name attr
+    then readLocalPackage src name attr
     else throw "Unknown package type ${attr.type}";
 
   # Option 1: Fetch and unpack the given package from the registry
@@ -94,62 +97,151 @@
     };
 
   # Read all the locked packages
-  lockedPackages = lock: lib.mapAttrs readLockedPackage lock.packages;
+  lockedPackages = src: lock:
+    lib.mapAttrs (readLockedPackage src) lock.packages;
 
-  workspaces = {
-    lockfile,
+  # Read a workspace package. These are listed at the top of the
+  # lockfile, not in the main packages list.
+  readWorkspacePackage = src: name: attr:
+    stdenv.mkDerivation {
+      name = name;
+      # The workspace packages list version ranges with their dependencies, so
+      # we want to take only the keys.
+      dependencies = let
+        toNames = dep:
+          if builtins.typeOf dep == "set"
+          then lib.attrNames dep
+          else [dep];
+      in
+        lib.concatMap toNames attr.dependencies;
+      src =
+        if attr.path == "./"
+        then src
+        else pathExists "${src}/${attr.path}";
+      installPhase = ''
+        cp -R . $out
+      '';
+    };
+
+  # Read the workspace packages
+  workspacePackages = src: lock:
+    lib.mapAttrs (readWorkspacePackage src) lock.workspace.packages;
+
+  # Link the directories within the 'output' directory of a dependency forward
+  # into the output directory of the current package. This supports incremental
+  # compilation.
+  linkOutput = lib.concatMapStringsSep "\n" (dep: ''
+    if [ -d "${dep}/output" ]; then
+      for dir in "${dep}/output"/*; do
+        if [ -d "$dir" ]; then
+          echo "Linking $dir"
+          base_dir=$(basename "$dir")
+          if [ ! -d "output/$base_dir" ]; then
+            ln -s "$dir" "output/$base_dir"
+          fi
+        fi
+      done
+    fi
+  '');
+  
+  # Merge the cache-db.json files of all the dependencies so the compiler knows
+  # not to rebuild them.
+  mergeCacheDb = deps: ''
+    caches=()
+    for dir in ${lib.concatStringsSep " " deps}
+    do
+      caches+="$dir/output/cache-db.json "
+    done
+    # Merge cache-db.json files and write them to the output directory
+    jq -s 'reduce .[] as $item ({}; reduce ($item|keys_unsorted[]) as $key (.; .[$key] += $item[$key]))' $caches > output/cache-db.json
+    '';
+
+  fixDependencies = purs: deps:
+    lib.fix (self:
+      lib.mapAttrs (name: drv: let
+        get-dep = dep: self.${dep};
+
+        directs = builtins.listToAttrs (map (name: {
+            name = name;
+            value = get-dep name;
+          })
+          drv.dependencies);
+
+        transitive = builtins.foldl' (a: pkg: a // self.${pkg}.dependencies) {} drv.dependencies;
+
+        dependencies = transitive // directs;
+      in
+        stdenv.mkDerivation rec {
+          name = drv.name;
+
+          src = drv.out;
+
+          nativeBuildInputs = [purs jq];
+
+          phases = ["buildPhase" "installPhase" "checkPhase"];
+
+          passthru = {
+            inherit dependencies;
+          };
+
+          # TODO: The 'files' key can indicate additional deps.
+          globs =
+            ["${src}/src/**/*.purs"]
+            ++ map (dep: ''"${dep.src}/src/**/*.purs"'') (builtins.attrValues dependencies);
+
+          preBuild = ''
+            mkdir output
+            ${linkOutput (builtins.attrValues directs)}
+            ${mergeCacheDb (builtins.attrValues directs)}
+          '';
+
+          buildPhase = ''
+            runHook preBuild
+
+            cleanup() {
+              exit_code=$?
+              if [ $exit_code -ne 0 ]; then
+                echo "purs compile failed with exit code $exit_code."
+                cat purs-log.txt
+              fi
+              exit $exit_code
+            }
+
+            trap cleanup EXIT
+
+            # TODO: Ideally we would only compile to corefn if we know it's
+            # necessary (for example, a 'backend' command was supplied).
+            set -f
+            purs compile ${lib.concatStringsSep " " globs} --codegen corefn,js 2>&1 | tee purs-log.txt
+            set +f
+          '';
+
+          installPhase = ''
+            mkdir $out
+            mv output $out/output
+          '';
+
+          doCheck = true;
+          checkPhase = ''
+            FILE_COUNT=$(find ${src}/src -name '*.purs' | wc -l)
+            COMPILE_LINE=$(grep -m 1 "^\[[0-9]* of [0-9]*\] Compiling" purs-log.txt)
+            MODULE_COUNT=$(echo $COMPILE_LINE | sed -n 's/^\[\([0-9]*\) of \([0-9]*\)\] Compiling.*$/\2/p')
+            if [[ $FILE_COUNT -ne $MODULE_COUNT ]]; then
+              echo ".purs file count ($FILE_COUNT) does not match the module count ($MODULE_COUNT)."
+              echo "This indicates incremental compilation is wrong."
+              cat purs-log.txt
+              exit 1
+            fi
+          '';
+        }) deps);
+
+  buildSpagoLock = {
+    purs ? purs-bin.purs-0_15_9,
+    lockfile ? src + "/spago.lock",
     src,
   }: let
     lock = readSpagoLock lockfile;
-
-    # Read the workspace packages
-    workspacePackages = lib.mapAttrs readWorkspacePackage lock.workspace.packages;
-
-    # Union all packages so they can be used as a little package database
-    allPackages = lockedPackages lock // workspacePackages;
-
-    closureEntry = name: {
-      key = name;
-      package = allPackages.${name} or (builtins.throw ''Missing package "${name}"'');
-    };
-
-    workspaceClosure = workspace:
-      builtins.genericClosure {
-        startSet = map closureEntry workspace.dependencies;
-        operator = entry: map closureEntry entry.package.dependencies;
-      };
-
-    # Read a workspace package. These are listed at the top of the
-    # lockfile, not in the main packages list.
-    readWorkspacePackage = name: attr:
-      stdenv.mkDerivation {
-        name = name;
-        # The workspace packages list version ranges with their dependencies, so
-        # we want to take only the keys.
-        dependencies = let
-          toNames = dep:
-            if builtins.typeOf dep == "set"
-            then lib.attrNames dep
-            else [dep];
-        in
-          lib.concatMap toNames attr.dependencies;
-        src =
-          if attr.path == "./"
-          then src
-          else pathExists "${src}/${attr.path}";
-        installPhase = ''
-          cp -R . $out
-        '';
-      };
-
-    buildWorkspace = name: workspace: {
-      dependencies = rec {
-        # Get all dependencies of the workspace
-        sources = map (pkg: pkg.package) (workspaceClosure workspace);
-        # Turn them into glob patterns acceptable for the compiler
-        globs = builtins.concatStringsSep " " (map (path: "'${path}/src/**/*.purs'") sources);
-      };
-    };
   in
-    lib.mapAttrs buildWorkspace workspacePackages;
+    fixDependencies purs
+    (lockedPackages src lock // workspacePackages src lock);
 }

--- a/nix/tests/spago-lock/default.nix
+++ b/nix/tests/spago-lock/default.nix
@@ -1,42 +1,36 @@
-{callPackage}: let
-  utils = callPackage ../utils.nix {};
-  fromYAML = callPackage ../../from-yaml.nix {};
-  lock = callPackage ../../spago-lock.nix {inherit fromYAML;};
-in
-  utils.runTests {
-    testSimpleLock = {
-      expr = let
-        locked = lock.readSpagoLock ./simple.lock;
-      in
-        builtins.attrNames (locked.packages // locked.workspace.packages);
-      expected = ["basic" "console" "effect" "prelude"];
-    };
+{ callPackage }:
+let
+  utils = callPackage ../utils.nix { };
+  fromYAML = callPackage ../../from-yaml.nix { };
+  lock = callPackage ../../spago-lock.nix { inherit fromYAML; };
+in utils.runTests {
+  testSimpleLock = {
+    expr = let locked = lock.readSpagoLock ./simple.lock;
+    in builtins.attrNames (locked.packages // locked.workspace.packages);
+    expected = [ "basic" "console" "effect" "prelude" ];
+  };
 
-    testSimpleconfig = {
-      expr = lock.readSpagoConfig ./simple.yaml;
-      expected = {
-        package = {
-          name = "basic";
-          dependencies = ["console" "effect" "prelude"];
-          test = {
-            dependencies = [];
-            main = "Test.Main";
-          };
-        };
-        workspace = {
-          extra_packages = {};
-          package_set = {
-            registry = "25.2.1";
-          };
+  testSimpleconfig = {
+    expr = lock.readSpagoConfig ./simple.yaml;
+    expected = {
+      package = {
+        name = "basic";
+        dependencies = [ "console" "effect" "prelude" ];
+        test = {
+          dependencies = [ ];
+          main = "Test.Main";
         };
       };
+      workspace = {
+        extra_packages = { };
+        package_set = { registry = "25.2.1"; };
+      };
     };
+  };
 
-    testWorkspaceLock = {
-      expr = let
-        locked = lock.readSpagoLock ./workspaces.lock;
-      in
-        builtins.attrNames (locked.workspace.packages);
-      expected = ["bin" "lib"];
-    };
-  }
+  testWorkspaceLock = {
+    expr = let locked = lock.readSpagoLock ./workspaces.lock;
+    in builtins.attrNames (locked.workspace.packages);
+    expected = [ "bin" "lib" ];
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -11,7 +11,7 @@ final: prev: let
   purix = {
     lib = buildPackageLock // buildSpagoLock;
     buildPackageLock = buildPackageLock.buildPackageLock;
-    buildSpagoLock = buildSpagoLock.workspaces;
+    buildSpagoLock = buildSpagoLock.buildSpagoLock;
   };
 in
   {purix = purix;} // tooling


### PR DESCRIPTION
This allows you to change your source code and only recompile what's changed. The symlink implementation is unfortunately very slow — might need to explore Bash associative arrays to get around that.