### PR TITLE
Handle npm workspaces appropriately

### DIFF
--- a/nix/examples/default.nix
+++ b/nix/examples/default.nix
@@ -3,4 +3,5 @@
 {callPackage}: {
   simple = callPackage ./simple {};
   simple-ffi = callPackage ./simple-ffi {};
+  npm-workspaces = callPackage ./npm-workspaces {};
 }

--- a/nix/examples/npm-workspaces/app/package.json
+++ b/nix/examples/npm-workspaces/app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "app",
+  "private": true,
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "foreign": "file:../foreign",
+    "lib": "file:../lib",
+    "xhr2": "^0.2.1"
+  }
+}

--- a/nix/examples/npm-workspaces/default.nix
+++ b/nix/examples/npm-workspaces/default.nix
@@ -1,0 +1,13 @@
+{
+  stdenv,
+  purix,
+}: let
+  packageLock = purix.buildPackageLock {src = ./.;};
+in
+  stdenv.mkDerivation {
+    name = "npm-workspaces";
+    src = ./.;
+    installPhase = ''
+      cp -r ${packageLock}/js/node_modules $out
+    '';
+  }

--- a/nix/examples/npm-workspaces/foreign/package.json
+++ b/nix/examples/npm-workspaces/foreign/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspace-foreign",
+  "private": true,
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "lib": "file:../lib",
+    "tmp": "^0.2.1"
+  }
+}

--- a/nix/examples/npm-workspaces/lib/package.json
+++ b/nix/examples/npm-workspaces/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-lib",
+  "private": true,
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "spdx-expression-parse": "^3.0.0"
+  }
+}

--- a/nix/examples/npm-workspaces/package-lock.json
+++ b/nix/examples/npm-workspaces/package-lock.json
@@ -1,0 +1,199 @@
+{
+  "name": "npm-workspaces",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-workspaces",
+      "workspaces": [
+        "app",
+        "foreign",
+        "lib"
+      ]
+    },
+    "app": {
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "foreign": "file:../foreign",
+        "lib": "file:../lib",
+        "xhr2": "^0.2.1"
+      }
+    },
+    "foreign": {
+      "name": "workspace-foreign",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lib": "file:../lib",
+        "tmp": "^0.2.1"
+      }
+    },
+    "lib": {
+      "name": "workspace-lib",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/app": {
+      "resolved": "app",
+      "link": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/foreign": {
+      "resolved": "foreign",
+      "link": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/lib": {
+      "resolved": "lib",
+      "link": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w=="
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/workspace-foreign": {
+      "resolved": "foreign",
+      "link": true
+    },
+    "node_modules/workspace-lib": {
+      "resolved": "lib",
+      "link": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    }
+  }
+}

--- a/nix/examples/npm-workspaces/package.json
+++ b/nix/examples/npm-workspaces/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "npm-workspaces",
+  "private": true,
+  "workspaces": [
+    "app",
+    "foreign",
+    "lib"
+  ]
+}


### PR DESCRIPTION
NPM workspaces are placed in the package-lock.json file, but (for PureScript projects) I think it's OK to remove them from the resulting node_modules. We at the very least can't fetch a tarball for them and add them to the NPM cache; we could possibly move them into the node_modules as local dependencies, but we're generally going to rely on Spago workspaces to manage multiple PureScript projects together and use NPM workspaces only to fetch the relevant dependencies for each project.