### PR TITLE
Apply source filtering to package-lock and spago-lock

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,9 +60,7 @@
         program = "${bin}/bin/${bin.pname or bin.name}";
       };
       apps = pkgs.lib.mapAttrs (_: mkApp) self.packages.${system};
-      scripts = {
-        generate = mkApp (pkgs.callPackage ./generate {});
-      };
+      scripts = {generate = mkApp (pkgs.callPackage ./generate {});};
     in
       apps // scripts);
 


### PR DESCRIPTION
Right now, if you have a project with the `package-lock.json` or `spago.lock` in the root of the repo, then changing any file will cause rebuilds. This helps mitigate that by filtering the provided source.