### PR TITLE
suggestion to include `purescript-language-server` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ In a Nix flake, use the provided overlay when importing nixpkgs to get access to
             pkgs.spago-unstable
             pkgs.purs-tidy-bin.purs-tidy-0_10_0
             pkgs.purs-backend-es
+            pkgs.nodePackages.purescript-language-server # from NixPkgs
           ];
         };
       }


### PR DESCRIPTION
Closes: https://github.com/thomashoneyman/purescript-overlay/issues/44
Only a suggestion

I.m.o. this supports `direnv` and LSP users.

Test:
```
purescript-overlay-test$ which purescript-language-server 
/nix/store/6mqk8yzjyvk230w2j52m550xpdg8mw8v-purescript-language-server-0.17.1/bin/purescript-language-server
```

from NixPkgs:
https://search.nixos.org/packages?channel=unstable&show=nodePackages.purescript-language-server&from=0&size=50&sort=relevance&type=packages&query=purescript-language-server