### PR TITLE
Auto-update spago@next

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688609058,
-        "narHash": "sha256-ehzS5vsaEdTve4ivw33PZ1orDdQJxpdLbK1VQLcRxws=",
+        "lastModified": 1697721701,
+        "narHash": "sha256-ZXzpljto5bbUthHtvqs8IvGuL1lADtmtylzp0BOp6bE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "15b5303444726346ee9d95bc890e8317c4f437b1",
+        "rev": "c6a1420d769355faf9ec3fedf9b48d91796489db",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688610262,
-        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
         "owner": "thomashoneyman",
         "repo": "slimlock",
-        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
           self.packages.${system}.purs-tidy-unstable
           self.packages.${system}.purs-backend-es-unstable
           self.packages.${system}.purescript-language-server-unstable
-          pkgs.nodejs_20
+          pkgs.nodejs_18
         ];
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -149,6 +149,7 @@
           self.packages.${system}.purs-tidy-unstable
           self.packages.${system}.purs-backend-es-unstable
           self.packages.${system}.purescript-language-server-unstable
+          pkgs.nodejs_20
         ];
       };
     });

--- a/generate/bin/src/AppM.purs
+++ b/generate/bin/src/AppM.purs
@@ -13,7 +13,7 @@ import Effect.Class (class MonadEffect)
 import Lib.Foreign.Octokit (GitHubError, Octokit)
 import Lib.Git (GitM(..))
 import Lib.GitHub (GitHubM(..))
-import Lib.Nix.Manifest (NamedManifest, PursBackendEsManifest, PursManifest, PursTidyManifest, SpagoManifest, PursLanguageServerManifest)
+import Lib.Nix.Manifest (CombinedManifest, GitHubBinaryManifest, NamedManifest, NPMRegistryManifest)
 import Lib.Nix.Manifest as Nix.Manifest
 import Lib.Nix.Manifest as Tool
 import Lib.Tool (Tool(..))
@@ -78,52 +78,52 @@ getToolManifestPath tool = do
   { manifestDir } <- ask
   pure $ Path.concat [ manifestDir, Tool.filename tool ]
 
-readPursManifest :: AppM PursManifest
+readPursManifest :: AppM GitHubBinaryManifest
 readPursManifest = do
   path <- getToolManifestPath Purs
-  Utils.readJsonFile path Nix.Manifest.pursManifestCodec
+  Utils.readJsonFile path Nix.Manifest.githubBinaryManifestCodec
 
-writePursManifest :: PursManifest -> AppM Unit
+writePursManifest :: GitHubBinaryManifest -> AppM Unit
 writePursManifest manifest = do
   path <- getToolManifestPath Purs
-  Utils.writeJsonFile path Nix.Manifest.pursManifestCodec manifest
+  Utils.writeJsonFile path Nix.Manifest.githubBinaryManifestCodec manifest
 
-readSpagoManifest :: AppM SpagoManifest
+readSpagoManifest :: AppM CombinedManifest
 readSpagoManifest = do
   path <- getToolManifestPath Spago
-  Utils.readJsonFile path Nix.Manifest.spagoManifestCodec
+  Utils.readJsonFile path Nix.Manifest.combinedManifestCodec
 
-writeSpagoManifest :: SpagoManifest -> AppM Unit
+writeSpagoManifest :: CombinedManifest -> AppM Unit
 writeSpagoManifest manifest = do
   path <- getToolManifestPath Spago
-  Utils.writeJsonFile path Nix.Manifest.spagoManifestCodec manifest
+  Utils.writeJsonFile path Nix.Manifest.combinedManifestCodec manifest
 
-readPursTidyManifest :: AppM PursTidyManifest
+readPursTidyManifest :: AppM NPMRegistryManifest
 readPursTidyManifest = do
   path <- getToolManifestPath PursTidy
-  Utils.readJsonFile path Nix.Manifest.pursTidyManifestCodec
+  Utils.readJsonFile path Nix.Manifest.npmRegistryManifestCodec
 
-writePursTidyManifest :: PursTidyManifest -> AppM Unit
+writePursTidyManifest :: NPMRegistryManifest -> AppM Unit
 writePursTidyManifest manifest = do
   path <- getToolManifestPath PursTidy
-  Utils.writeJsonFile path Nix.Manifest.pursTidyManifestCodec manifest
+  Utils.writeJsonFile path Nix.Manifest.npmRegistryManifestCodec manifest
 
-readPursBackendEsManifest :: AppM PursBackendEsManifest
+readPursBackendEsManifest :: AppM NPMRegistryManifest
 readPursBackendEsManifest = do
   path <- getToolManifestPath PursBackendEs
-  Utils.readJsonFile path Nix.Manifest.pursTidyManifestCodec
+  Utils.readJsonFile path Nix.Manifest.npmRegistryManifestCodec
 
-writePursBackendEsManifest :: PursBackendEsManifest -> AppM Unit
+writePursBackendEsManifest :: NPMRegistryManifest -> AppM Unit
 writePursBackendEsManifest manifest = do
   path <- getToolManifestPath PursBackendEs
-  Utils.writeJsonFile path Nix.Manifest.pursTidyManifestCodec manifest
+  Utils.writeJsonFile path Nix.Manifest.npmRegistryManifestCodec manifest
 
-readPursLanguageServerManifest :: AppM PursLanguageServerManifest
+readPursLanguageServerManifest :: AppM NPMRegistryManifest
 readPursLanguageServerManifest = do
   path <- getToolManifestPath PursLanguageServer
-  Utils.readJsonFile path Nix.Manifest.pursLanguageServerManifestCodec
+  Utils.readJsonFile path Nix.Manifest.npmRegistryManifestCodec
 
-writePursLanguageServerManifest :: PursLanguageServerManifest -> AppM Unit
+writePursLanguageServerManifest :: NPMRegistryManifest -> AppM Unit
 writePursLanguageServerManifest manifest = do
   path <- getToolManifestPath PursLanguageServer
-  Utils.writeJsonFile path Nix.Manifest.pursLanguageServerManifestCodec manifest
+  Utils.writeJsonFile path Nix.Manifest.npmRegistryManifestCodec manifest

--- a/generate/bin/src/Main.purs
+++ b/generate/bin/src/Main.purs
@@ -79,31 +79,31 @@ main = Aff.launchAff_ do
           if Map.isEmpty updates then
             Console.log "No new purs releases."
           else
-            Console.log $ "New purs releases: " <> Utils.printJson Nix.Manifest.pursManifestCodec updates
+            Console.log $ "New purs releases: " <> Utils.printJson Nix.Manifest.githubBinaryManifestCodec updates
 
         Run.prefetchSpago >>= \updates ->
           if Map.isEmpty updates then
             Console.log "No new spago releases."
           else
-            Console.log $ "New spago releases: " <> Utils.printJson Nix.Manifest.spagoManifestCodec updates
+            Console.log $ "New spago releases: " <> Utils.printJson Nix.Manifest.combinedManifestCodec updates
 
         Run.prefetchPursTidy >>= \updates ->
           if Map.isEmpty updates then
             Console.log "No new purs-tidy releases."
           else
-            Console.log $ "New purs-tidy releases: " <> Utils.printJson Nix.Manifest.pursTidyManifestCodec updates
+            Console.log $ "New purs-tidy releases: " <> Utils.printJson Nix.Manifest.npmRegistryManifestCodec updates
 
         Run.prefetchPursBackendEs >>= \updates ->
           if Map.isEmpty updates then
             Console.log "No new purs-backend-es releases."
           else
-            Console.log $ "New purs-backend-es releases: " <> Utils.printJson Nix.Manifest.pursBackendEsManifestCodec updates
+            Console.log $ "New purs-backend-es releases: " <> Utils.printJson Nix.Manifest.npmRegistryManifestCodec updates
 
         Run.prefetchPursLanguageServer >>= \updates ->
           if Map.isEmpty updates then
             Console.log "No new purescript-language-server releases."
           else
-            Console.log $ "New purescript-language-server releases: " <> Utils.printJson Nix.Manifest.pursLanguageServerManifestCodec updates
+            Console.log $ "New purescript-language-server releases: " <> Utils.printJson Nix.Manifest.npmRegistryManifestCodec updates
 
     Update dir commit -> do
       let envFile = Path.concat [ dir, "..", "generate", ".env" ]

--- a/generate/bin/src/Run.purs
+++ b/generate/bin/src/Run.purs
@@ -143,10 +143,15 @@ prefetchSpago = do
             Version.major version > 0
               || (Version.major version == 0 && Version.minor version >= 93)
 
+          notBroken :: Boolean
+          notBroken = Array.notElem version
+            [ unsafeVersion "0.93.7" -- bad bundle, fails with 'ReferenceError: __dirname is not defined in ES module scope'
+            ]
+
           notPrerelease :: Boolean
           notPrerelease = isNothing pre
 
-        satisfiesLowerLimit && notPrerelease
+        satisfiesLowerLimit && notBroken && notPrerelease
     }
 
   -- Spago was rewritten from Haskell to PureScript, so we only get the Haskell

--- a/generate/bin/src/Run.purs
+++ b/generate/bin/src/Run.purs
@@ -20,7 +20,6 @@ import Prelude
 
 import Bin.AppM (AppM)
 import Bin.AppM as AppM
-import Control.Alt ((<|>))
 import Control.Alternative (guard)
 import Data.Array as Array
 import Data.Either (Either(..), fromRight')
@@ -31,7 +30,6 @@ import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing)
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (alaF)
-import Data.Set (Set)
 import Data.Set as Set
 import Data.String as String
 import Data.Traversable (foldMap, for)

--- a/generate/lib/spago.yaml
+++ b/generate/lib/spago.yaml
@@ -3,6 +3,7 @@ package:
   dependencies:
     - aff-promise
     - argonaut-core
+    - b64
     - codec-argonaut
     - effect
     - fetch

--- a/generate/lib/spago.yaml
+++ b/generate/lib/spago.yaml
@@ -5,6 +5,7 @@ package:
     - argonaut-core
     - codec-argonaut
     - effect
+    - fetch
     - http-methods
     - node-execa
     - prelude

--- a/generate/lib/src/NPMRegistry.purs
+++ b/generate/lib/src/NPMRegistry.purs
@@ -2,17 +2,21 @@ module Lib.NPMRegistry where
 
 import Prelude
 
-import Data.Argonaut.Parser as Argonaut
-import Data.Bifunctor (lmap)
+import Data.Argonaut.Core as Argonaut
+import Data.Argonaut.Parser as Argonaut.Parser
 import Data.Codec.Argonaut (JsonCodec)
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Common as CA.Common
 import Data.Codec.Argonaut.Record as CA.Record
 import Data.Either (Either(..))
 import Data.Map (Map)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..))
+import Data.Profunctor as Profunctor
+import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Fetch as Fetch
+import Foreign.Object as Object
+import Lib.Git (CommitSha(..))
 import Lib.SemVer (SemVer)
 import Lib.SemVer as SemVer
 import Lib.Tool (Tool(..))
@@ -29,11 +33,23 @@ listNPMReleases tool = do
   if status /= 200 then do
     pure $ Left $ "Received non-200 status in request to NPM registry: " <> response
   else do
-    case (lmap CA.printJsonDecodeError <<< CA.decode npmPackageCodec) =<< Argonaut.jsonParser response of
-      Left err -> do
-        pure $ Left $ "Failed to decode NPM response: " <> err <> "\n\n from raw text: " <> response
-      Right npmPackage ->
-        pure $ Right $ npmPackage.versions
+    case Argonaut.Parser.jsonParser response of
+      Left parseErr ->
+        pure $ Left $ "NPM response is not valid JSON: " <> parseErr <> "\n\n from raw text: " <> response
+      Right json -> case CA.decode npmPackageCodec json of
+        Left decodeErr -> do
+          let err = CA.printJsonDecodeError decodeErr
+          case Argonaut.toObject json of
+            Nothing -> pure $ Left $ "Failed to decode NPM response: " <> err <> "\n\n because NPM response is not an object in raw text: " <> response
+            Just obj -> case Object.lookup "versions" obj of
+              Nothing -> pure $ Left "NPM response has no 'versions' key!"
+              Just versionsJson -> case Argonaut.toObject versionsJson of
+                Nothing -> pure $ Left "NPM response has a 'versions' key, but it's not an object!"
+                Just versionsObject -> case traverse (CA.decode npmVersionCodec) versionsObject of
+                  Left decodeErr2 -> pure $ Left $ "Failed to decode NPM response: " <> CA.printJsonDecodeError decodeErr2
+                  Right _ -> pure $ Left $ "Failed to decode NPM response (versions OK): " <> err <> "\n\n " <> Argonaut.stringify (Argonaut.fromObject (Object.delete "versions" obj))
+        Right npmPackage ->
+          pure $ Right $ npmPackage.versions
 
 printNPMRegistryUrl :: Tool -> String
 printNPMRegistryUrl = case _ of
@@ -58,6 +74,7 @@ type NPMVersion =
   { name :: String
   , version :: SemVer
   , main :: Maybe FilePath
+  , gitHead :: Maybe CommitSha
   , dependencies :: Maybe (Map String String)
   , dist :: NPMVersionDist
   }
@@ -66,6 +83,7 @@ npmVersionCodec :: JsonCodec NPMVersion
 npmVersionCodec = CA.Record.object "NPMVersion"
   { name: CA.string
   , version: SemVer.codec
+  , gitHead: CA.Record.optional (Profunctor.wrapIso CommitSha CA.string)
   , main: CA.Record.optional CA.string
   , dependencies: CA.Record.optional (CA.Common.strMap CA.string)
   , dist: npmVersionDistCodec

--- a/generate/lib/src/NPMRegistry.purs
+++ b/generate/lib/src/NPMRegistry.purs
@@ -1,0 +1,81 @@
+module Lib.NPMRegistry where
+
+import Prelude
+
+import Data.Codec.Argonaut (JsonCodec)
+import Data.Codec.Argonaut as CA
+import Data.Codec.Argonaut.Common as CA.Common
+import Data.Codec.Argonaut.Record as CA.Record
+import Data.Either (Either(..))
+import Data.Map (Map)
+import Effect.Aff (Aff)
+import Fetch as Fetch
+import Foreign (unsafeFromForeign)
+import Lib.SemVer (SemVer)
+import Lib.SemVer as SemVer
+import Lib.Tool (Tool(..))
+import Node.Path (FilePath)
+
+-- NOTE: Spago bundles all but better-sqlite3 in their release process,
+-- so I need to handle that somehow. Like some kind of 'extra_node_modules'
+-- I can apply.
+
+listNPMReleases :: Tool -> Aff (Either String (Map SemVer NPMVersion))
+listNPMReleases tool = do
+  { status, json, text } <- Fetch.fetch (printNPMRegistryUrl tool) {}
+  if status /= 200 then do
+    response <- text
+    pure $ Left $ "Received non-200 status in request to NPM registry: " <> response
+  else do
+    response <- unsafeFromForeign <$> json
+    case CA.decode npmPackageCodec response of
+      Left err -> do
+        responseText <- text
+        pure $ Left $ "Failed to decode NPM response: " <> CA.printJsonDecodeError err <> "\n\n from raw text: " <> responseText
+      Right npmPackage ->
+        pure $ Right $ npmPackage.versions
+
+printNPMRegistryUrl :: Tool -> String
+printNPMRegistryUrl = case _ of
+  Purs -> "https://registry.npmjs.org/purescript"
+  Spago -> "https://registry.npmjs.org/spago"
+  PursTidy -> "https://registry.npmjs.org/purs-tidy"
+  PursBackendEs -> "https://registry.npmjs.org/purescript-backend-es"
+  PursLanguageServer -> "https://registry.npmjs.org/purescript-language-server"
+
+type NPMPackage =
+  { name :: String
+  , versions :: Map SemVer NPMVersion
+  }
+
+npmPackageCodec :: JsonCodec NPMPackage
+npmPackageCodec = CA.Record.object "NPMPackage"
+  { name: CA.string
+  , versions: SemVer.semverMapCodec npmVersionCodec
+  }
+
+type NPMVersion =
+  { name :: String
+  , version :: SemVer
+  , main :: FilePath
+  , dependencies :: Map String String
+  , dist :: NPMVersionDist
+  }
+
+npmVersionCodec :: JsonCodec NPMVersion
+npmVersionCodec = CA.Record.object "NPMVersion"
+  { name: CA.string
+  , version: SemVer.codec
+  , main: CA.string
+  , dependencies: CA.Common.strMap CA.string
+  , dist: npmVersionDistCodec
+  }
+
+type NPMVersionDist =
+  { tarball :: String
+  }
+
+npmVersionDistCodec :: JsonCodec NPMVersionDist
+npmVersionDistCodec = CA.Record.object "NPMVersionDist"
+  { tarball: CA.string
+  }

--- a/generate/lib/src/Nix/Manifest.purs
+++ b/generate/lib/src/Nix/Manifest.purs
@@ -92,12 +92,12 @@ npmFetchCodec = CA.codec' decode encode
     Bundled fetchUrl -> CA.encode fetchUrlCodec fetchUrl
     Unbundled fetchUrlAndLock -> CA.encode fetchUrlAndLockCodec fetchUrlAndLock
 
-type FetchUrlAndLock = { tarball :: FetchUrl, lockfile :: FetchUrl }
+type FetchUrlAndLock = { tarball :: FetchUrl, lockfile :: FilePath }
 
 fetchUrlAndLockCodec :: JsonCodec FetchUrlAndLock
 fetchUrlAndLockCodec = CA.Record.object "FetchUrlAndLock"
   { tarball: fetchUrlCodec
-  , lockfile: fetchUrlCodec
+  , lockfile: CA.string
   }
 
 -- | A manifest entry for a package which has a fetchable tarball

--- a/generate/lib/src/Nix/Prefetch.purs
+++ b/generate/lib/src/Nix/Prefetch.purs
@@ -1,5 +1,5 @@
 module Lib.Nix.Prefetch
-  ( nixPrefetchTarball
+  ( nixPrefetch
   ) where
 
 import Prelude
@@ -13,8 +13,8 @@ import Node.Library.Execa as Execa
 import Registry.Sha256 (Sha256)
 import Registry.Sha256 as Sha256
 
-nixPrefetchTarball :: forall m. MonadAff m => String -> m (Either String Sha256)
-nixPrefetchTarball url = Except.runExceptT do
+nixPrefetch :: forall m. MonadAff m => String -> m (Either String Sha256)
+nixPrefetch url = Except.runExceptT do
   nixHash <- ExceptT (nixPrefetchUrl url)
   sha256 <- ExceptT (nixHashToSha256 nixHash)
   pure sha256

--- a/generate/lib/test/Test/Lib/Manifest.purs
+++ b/generate/lib/test/Test/Lib/Manifest.purs
@@ -9,7 +9,7 @@ import Data.Codec.Argonaut as CA
 import Data.Either (Either(..))
 import Data.String as String
 import Data.Traversable (for)
-import Lib.Nix.Manifest (NamedManifest, PursBackendEsManifest, PursLanguageServerManifest, PursManifest, PursTidyManifest, SpagoManifest, namedManifestCodec, pursBackendEsManifestCodec, pursLanguageServerManifestCodec, pursManifestCodec, pursTidyManifestCodec, spagoManifestCodec)
+import Lib.Nix.Manifest (CombinedManifest, GitHubBinaryManifest, NPMRegistryManifest, NamedManifest, combinedManifestCodec, githubBinaryManifestCodec, namedManifestCodec, npmRegistryManifestCodec)
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
@@ -20,7 +20,7 @@ import Test.Utils as Utils
 spec :: Spec Unit
 spec = do
   Spec.it "Round-trips manifest fixtures" do
-    let manifestFixturesPath = Path.concat [ "..", "..", "manifests" ]
+    let manifestFixturesPath = Path.concat [ "..", "manifests" ]
     paths <- FS.Aff.readdir manifestFixturesPath
     let fixturePaths = Array.filter (\path -> Path.extname path == ".json") paths
     fixtures <- for fixturePaths \path -> do
@@ -29,11 +29,11 @@ spec = do
     Utils.shouldRoundTrip "Manifest" nixManifestCodec fixtures
 
 data NixManifest
-  = SpagoManifest SpagoManifest
-  | PursManifest PursManifest
-  | PursTidyManifest PursTidyManifest
-  | PursBackendEsManifest PursBackendEsManifest
-  | PursLanguageServerManifest PursLanguageServerManifest
+  = SpagoManifest CombinedManifest
+  | PursManifest GitHubBinaryManifest
+  | PursTidyManifest NPMRegistryManifest
+  | PursBackendEsManifest NPMRegistryManifest
+  | PursLanguageServerManifest NPMRegistryManifest
   | NamedManifest NamedManifest
 
 derive instance Eq NixManifest
@@ -42,18 +42,18 @@ nixManifestCodec :: JsonCodec NixManifest
 nixManifestCodec = CA.codec' decode encode
   where
   encode = case _ of
-    SpagoManifest manifest -> CA.encode spagoManifestCodec manifest
-    PursManifest manifest -> CA.encode pursManifestCodec manifest
-    PursTidyManifest manifest -> CA.encode pursTidyManifestCodec manifest
-    PursBackendEsManifest manifest -> CA.encode pursBackendEsManifestCodec manifest
-    PursLanguageServerManifest manifest -> CA.encode pursLanguageServerManifestCodec manifest
+    SpagoManifest manifest -> CA.encode combinedManifestCodec manifest
+    PursManifest manifest -> CA.encode githubBinaryManifestCodec manifest
+    PursTidyManifest manifest -> CA.encode npmRegistryManifestCodec manifest
+    PursBackendEsManifest manifest -> CA.encode npmRegistryManifestCodec manifest
+    PursLanguageServerManifest manifest -> CA.encode npmRegistryManifestCodec manifest
     NamedManifest manifest -> CA.encode namedManifestCodec manifest
 
   decode json =
-    map SpagoManifest (CA.decode spagoManifestCodec json)
-      <|> map PursManifest (CA.decode pursManifestCodec json)
-      <|> map PursTidyManifest (CA.decode pursTidyManifestCodec json)
-      <|> map PursBackendEsManifest (CA.decode pursBackendEsManifestCodec json)
-      <|> map PursLanguageServerManifest (CA.decode pursLanguageServerManifestCodec json)
+    map SpagoManifest (CA.decode combinedManifestCodec json)
+      <|> map PursManifest (CA.decode githubBinaryManifestCodec json)
+      <|> map PursTidyManifest (CA.decode npmRegistryManifestCodec json)
+      <|> map PursBackendEsManifest (CA.decode npmRegistryManifestCodec json)
+      <|> map PursLanguageServerManifest (CA.decode npmRegistryManifestCodec json)
       <|> map NamedManifest (CA.decode namedManifestCodec json)
-      <|> Left (CA.TypeMismatch "Expected a SpagoManifest, PursManifest, PursTidyManifest, PursBackendEsManifest, PursLanguageServerManifest, or NamedManifest")
+      <|> Left (CA.TypeMismatch "Expected a CombinedManifest, GitHubBinaryManifest, NPMRegistryManifest, or NamedManifest")

--- a/generate/spago.lock
+++ b/generate/spago.lock
@@ -17,6 +17,7 @@ workspace:
       dependencies:
         - aff-promise
         - argonaut-core
+        - b64
         - codec-argonaut
         - effect
         - fetch
@@ -150,6 +151,20 @@ packages:
       - exceptions
       - functions
       - maybe
+  b64:
+    type: registry
+    version: 0.0.8
+    integrity: sha256-3QkOhnewZIqhfn0wIU6Zde6Q/LfrS59kgSOcQQaG0gM=
+    dependencies:
+      - arraybuffer-types
+      - either
+      - encoding
+      - enums
+      - exceptions
+      - functions
+      - partial
+      - prelude
+      - strings
   bifunctors:
     type: registry
     version: 6.0.0
@@ -300,6 +315,16 @@ packages:
       - control
       - invariant
       - maybe
+      - prelude
+  encoding:
+    type: registry
+    version: 0.0.8
+    integrity: sha256-n0HhENAax0yr7JFwZXcisx0jJvVf1dFwqd+Q5i2Pr88=
+    dependencies:
+      - arraybuffer-types
+      - either
+      - exceptions
+      - functions
       - prelude
   enums:
     type: registry

--- a/generate/spago.lock
+++ b/generate/spago.lock
@@ -19,6 +19,7 @@ workspace:
         - argonaut-core
         - codec-argonaut
         - effect
+        - fetch
         - http-methods
         - node-execa
         - prelude
@@ -330,6 +331,52 @@ packages:
     integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
+  fetch:
+    type: registry
+    version: 1.1.4
+    integrity: sha256-Tmt60rjS4PNtKMVGpo8O6W1Fdhcu3a3CvyN/x+SwXEs=
+    dependencies:
+      - aff
+      - aff-promise
+      - arraybuffer-types
+      - effect
+      - fetch-core
+      - foreign
+      - http-methods
+      - newtype
+      - prelude
+      - record
+      - typelevel-prelude
+      - unsafe-coerce
+      - web-file
+      - web-promise
+      - web-streams
+  fetch-core:
+    type: registry
+    version: 4.0.4
+    integrity: sha256-lS4yhvznII/vg37LewU/Ubeoj6OpxED2kb5/yn58YQQ=
+    dependencies:
+      - arraybuffer-types
+      - arrays
+      - console
+      - effect
+      - foldable-traversable
+      - foreign
+      - foreign-object
+      - functions
+      - http-methods
+      - maybe
+      - newtype
+      - nullable
+      - prelude
+      - record
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+      - unsafe-coerce
+      - web-file
+      - web-promise
+      - web-streams
   fixed-points:
     type: registry
     version: 7.0.0
@@ -603,6 +650,13 @@ packages:
     dependencies:
       - control
       - invariant
+      - newtype
+      - prelude
+  media-types:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=
+    dependencies:
       - newtype
       - prelude
   mmorph:
@@ -1246,3 +1300,49 @@ packages:
       - record
       - tuples
       - unsafe-coerce
+  web-dom:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=
+    dependencies:
+      - web-events
+  web-events:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=
+    dependencies:
+      - datetime
+      - enums
+      - foreign
+      - nullable
+  web-file:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=
+    dependencies:
+      - foreign
+      - media-types
+      - web-dom
+  web-promise:
+    type: registry
+    version: 3.1.0
+    integrity: sha256-YfqJyEC3bHH6D8QgTi0ME5oJmGYOuZ2TlcyOdpG8dIE=
+    dependencies:
+      - effect
+      - exceptions
+      - foldable-traversable
+      - functions
+      - maybe
+      - prelude
+  web-streams:
+    type: registry
+    version: 3.0.0
+    integrity: sha256-+QELAR7lb08Ebr4lCntxeGk5Z1i+NInDJwzEzz3Pigc=
+    dependencies:
+      - arraybuffer-types
+      - effect
+      - exceptions
+      - nullable
+      - prelude
+      - tuples
+      - web-promise

--- a/manifests/build-support/mkDerivation.nix
+++ b/manifests/build-support/mkDerivation.nix
@@ -9,7 +9,7 @@
   nodejs,
   runCommand,
   slimlock,
-  python3,
+  pkgs,
 }: version: source: let
   node_modules =
     if source.lockfile or {} != {}
@@ -22,7 +22,14 @@
         omit = ["dev" "peer"];
       })
       .overrideAttrs (final: prev: {
-        nativeBuildInputs = prev.nativeBuildInputs or [] ++ [python3];
+        nativeBuildInputs =
+          (prev.nativeBuildInputs or [])
+          ++ [pkgs.python3]
+          ++ (
+            if stdenv.isDarwin
+            then [pkgs.libtool]
+            else []
+          );
       })
     else {};
 in

--- a/manifests/build-support/mkDerivation.nix
+++ b/manifests/build-support/mkDerivation.nix
@@ -1,44 +1,72 @@
 {
   name,
   js,
-  meta
-}:
-{
+  meta,
+}: {
   lib,
   stdenv,
   fetchurl,
   nodejs,
-}:
-{
-  version,
-  url,
-  hash,
-}:
-stdenv.mkDerivation {
-  pname = name;
+  runCommand,
+  slimlock,
+  python3,
+}: version: source: let
+  node_modules =
+    if source.lockfile or {} != {}
+    then
+      (slimlock.buildPackageLock {
+        src = runCommand "package-lock-dir" {} ''
+          mkdir -p $out
+          cp ${./. + ("/" + source.lockfile)} $out/package-lock.json
+        '';
+        omit = ["dev" "peer"];
+      })
+      .overrideAttrs (final: prev: {
+        nativeBuildInputs = prev.nativeBuildInputs or [] ++ [python3];
+      })
+    else {};
+in
+  stdenv.mkDerivation {
+    pname = name;
 
-  inherit version;
+    inherit version;
 
-  src = fetchurl {inherit url hash;};
+    # Source is either { url, hash } or { tarball: { url, hash } }
+    src =
+      if source.url or {} != {}
+      then fetchurl source
+      else fetchurl source.tarball;
 
-  nativeBuildInputs = [nodejs];
+    nativeBuildInputs = [nodejs];
 
-  buildPhase = ''
-    tar xf $src
-  '';
+    buildPhase = ''
+      tar xf $src
+    '';
 
-  installPhase = ''
-    PACKAGE=$out/node_modules/${name}
-    mkdir -p $PACKAGE
-    mv package/* $PACKAGE
+    installPhase = ''
+      mkdir -p $out/node_modules
 
-    BIN=$PACKAGE/${js}
-    chmod +x $BIN
-    patchShebangs $BIN
+      ${
+        if node_modules != {}
+        then ''
+          cp -r ${node_modules}/js/node_modules $out
+        ''
+        else ''
+          echo "No package-lock.json found, not including node_modules."
+        ''
+      }
 
-    mkdir -p $out/bin
-    ln -s $BIN $out/bin/${name}
-  '';
+      PACKAGE=$out/node_modules/${name}
+      mkdir -p $PACKAGE
+      mv package/* $PACKAGE
 
-  meta = meta lib;
-}
+      BIN=$PACKAGE/${js}
+      chmod +x $BIN
+      patchShebangs $BIN
+
+      mkdir -p $out/bin
+      ln -s $BIN $out/bin/${name}
+    '';
+
+    meta = meta lib;
+  }

--- a/manifests/build-support/mkDerivation.nix
+++ b/manifests/build-support/mkDerivation.nix
@@ -24,12 +24,8 @@
       .overrideAttrs (final: prev: {
         nativeBuildInputs =
           (prev.nativeBuildInputs or [])
-          ++ [pkgs.python3]
-          ++ (
-            if stdenv.isDarwin
-            then [pkgs.libtool]
-            else []
-          );
+          ++ [pkgs.python3] # bump
+          ++ lib.optionals stdenv.isDarwin [pkgs.darwin.cctools];
       })
     else {};
 in

--- a/manifests/build-support/mkPursLanguageServerDerivation.nix
+++ b/manifests/build-support/mkPursLanguageServerDerivation.nix
@@ -4,16 +4,12 @@
   lib,
   nodejs,
   writeText,
-}: {
-  version,
-  url,
-  hash,
-}:
+}: version: source:
 stdenv.mkDerivation rec {
   pname = "purescript-language-server";
   inherit version;
 
-  src = fetchurl {inherit url hash;};
+  src = fetchurl source;
 
   nativeBuildInputs = [nodejs];
 

--- a/manifests/build-support/spago/better-sqlite3-8_6_0.json
+++ b/manifests/build-support/spago/better-sqlite3-8_6_0.json
@@ -1,0 +1,441 @@
+{
+  "name": "spago",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "better-sqlite3": "^8.7.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/better-sqlite3": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
+      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
+    "node_modules/node-abi": {
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
+      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/manifests/default.nix
+++ b/manifests/default.nix
@@ -7,11 +7,11 @@
   callPackage,
 }: let
   mkPursDerivation = callPackage ./build-support/mkPursDerivation.nix {};
+  mkLegacySpagoDerivation = callPackage ./build-support/mkLegacySpagoDerivation.nix {};
   mkSpagoDerivation = callPackage ./build-support/mkSpagoDerivation.nix {};
   mkPursTidyDerivation = callPackage ./build-support/mkPursTidyDerivation.nix {};
   mkPursBackendEsDerivation = callPackage ./build-support/mkPursBackendEsDerivation.nix {};
   mkPursLanguageServerDerivation = callPackage ./build-support/mkPursLanguageServerDerivation.nix {};
-  mkLegacySpagoDerivation = callPackage ./build-support/mkLegacySpagoDerivation.nix {};
 
   # The purs manifest uses fetchurl to fetch tarballs. We have to accommodate
   # missing systems.
@@ -43,11 +43,11 @@
         entry = entries.${version};
       in
         # To accommodate systems that don't work for legacy spago versions
-        if legacyEntry == {} && !(builtins.hasAttr "url" entry)
+        if legacyEntry == {} && !(builtins.hasAttr "url" entry) && !(builtins.hasAttr "lockfile" entry)
         then acc
         else if legacyEntry != {}
         then acc // {${name} = mkLegacySpagoDerivation ({inherit version;} // legacyEntry);}
-        else acc // {${name} = mkSpagoDerivation ({inherit version;} // entry);}
+        else acc // {${name} = mkSpagoDerivation version entry;}
     ) {}
     (builtins.attrNames entries);
 
@@ -59,7 +59,7 @@
       acc: version: let
         name = "purs-tidy-${builtins.replaceStrings ["."] ["_"] version}";
       in
-        acc // {${name} = mkPursTidyDerivation ({inherit version;} // entries.${version});}
+        acc // {${name} = mkPursTidyDerivation version entries.${version};}
     ) {}
     (builtins.attrNames entries);
 
@@ -71,7 +71,7 @@
       acc: version: let
         name = "purs-backend-es-${builtins.replaceStrings ["."] ["_"] version}";
       in
-        acc // {${name} = mkPursBackendEsDerivation ({inherit version;} // entries.${version});}
+        acc // {${name} = mkPursBackendEsDerivation version entries.${version};}
     ) {}
     (builtins.attrNames entries);
 
@@ -83,7 +83,7 @@
       acc: version: let
         name = "purescript-language-server-${builtins.replaceStrings ["."] ["_"] version}";
       in
-        acc // {${name} = mkPursLanguageServerDerivation ({inherit version;} // entries.${version});}
+        acc // {${name} = mkPursLanguageServerDerivation version entries.${version};}
     ) {}
     (builtins.attrNames entries);
 

--- a/manifests/named.json
+++ b/manifests/named.json
@@ -2,7 +2,7 @@
   "purs-stable": "purs-0_15_12",
   "purs-unstable": "purs-0_15_12",
   "spago-stable": "spago-0_21_0",
-  "spago-unstable": "spago-0_93_14",
+  "spago-unstable": "spago-0_93_18",
   "purs-tidy-stable": "purs-tidy-0_10_0",
   "purs-tidy-unstable": "purs-tidy-0_10_0",
   "purs-backend-es-stable": "purs-backend-es-1_4_2",

--- a/manifests/named.json
+++ b/manifests/named.json
@@ -2,7 +2,7 @@
   "purs-stable": "purs-0_15_12",
   "purs-unstable": "purs-0_15_12",
   "spago-stable": "spago-0_21_0",
-  "spago-unstable": "spago-0_93_18",
+  "spago-unstable": "spago-0_93_17",
   "purs-tidy-stable": "purs-tidy-0_10_0",
   "purs-tidy-unstable": "purs-tidy-0_10_0",
   "purs-backend-es-stable": "purs-backend-es-1_4_2",

--- a/manifests/purs-backend-es.json
+++ b/manifests/purs-backend-es.json
@@ -1,4 +1,24 @@
 {
+  "1.0.1": {
+    "hash": "sha256-UWS5b6OKDGAL+/Bx5oEGuFxnHlqdM1uPrbFxGAIqQjs=",
+    "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.0.1.tgz"
+  },
+  "1.0.2": {
+    "hash": "sha256-1ZZ06VCgKyB+1kjHkAd98hgoh4zE8++Ck8OLstYfFeg=",
+    "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.0.2.tgz"
+  },
+  "1.1.0": {
+    "hash": "sha256-UHG3OL1fDhpqra3miD3Nl9mazTv0oX05b3iM+Hs4934=",
+    "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.1.0.tgz"
+  },
+  "1.1.1": {
+    "hash": "sha256-LCBpxJn7mABRnZbKzgrofjjxqqaj3JM64T/xSAw8atQ=",
+    "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.1.1.tgz"
+  },
+  "1.2.0": {
+    "hash": "sha256-UZ3/OYik3rtn3kelVwhJzUqmPDrg0HaTP8Ch0F4I9fI=",
+    "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.2.0.tgz"
+  },
   "1.3.0": {
     "hash": "sha256-qE0LnuNSdJRsF07fhBAMY7OUGBNj6/hSPzDov7Nx4PY=",
     "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.3.0.tgz"
@@ -6,6 +26,10 @@
   "1.3.1": {
     "hash": "sha256-RoNk9/t9gijNGuPlm+9Synkzfw9YV4Fafv/WXhHhW2s=",
     "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.3.1.tgz"
+  },
+  "1.3.2": {
+    "hash": "sha256-H/zJ57rlEBCJd4OddOZXbEDQIG5IGPhBx+nGLEx/MOA=",
+    "url": "https://registry.npmjs.org/purs-backend-es/-/purs-backend-es-1.3.2.tgz"
   },
   "1.4.0": {
     "hash": "sha256-DdUZzRe0FcU0sU2U+iW6uV71BVGIyycA7ZQtkK3STNE=",

--- a/manifests/purs-tidy.json
+++ b/manifests/purs-tidy.json
@@ -15,9 +15,21 @@
     "hash": "sha256-Fl11hcu5JuDkOs6fOD7/K9F9q0IagG4Mwc9Cj7UzWI0=",
     "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.5.3.tgz"
   },
+  "0.5.4": {
+    "hash": "sha256-mUI8olgLw4ixAA2uKYB8yxkVmegYsSxOll+yDfMXeYE=",
+    "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.5.4.tgz"
+  },
   "0.6.0": {
     "hash": "sha256-Z/isCJQ3CPsux3b3wfBckU6Y7hcUBsJatSFq+l8QDUA=",
     "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.6.0.tgz"
+  },
+  "0.6.1": {
+    "hash": "sha256-tEcwlisKcxTitwznHiFhZIs2Igilx+rjeBVDCBBfhDw=",
+    "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.6.1.tgz"
+  },
+  "0.6.2": {
+    "hash": "sha256-lm5+Bnbm8Udbu6N2atuijgdu+C/TuJtArT9tCSVgYeQ=",
+    "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.6.2.tgz"
   },
   "0.6.3": {
     "hash": "sha256-jc8FrYam26BD4di02UCqAadpIzEz7aqrPzCJKoJ2Akc=",
@@ -46,6 +58,18 @@
   "0.9.0": {
     "hash": "sha256-k5hCrLOOIkHGtqQ8BOM2vB9auXvdMO4LttE18puLHyk=",
     "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.0.tgz"
+  },
+  "0.9.1": {
+    "hash": "sha256-GJviOnfPngig4QqDD0+KCAv377MeHy9AvNyikmG0GkA=",
+    "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.1.tgz"
+  },
+  "0.9.2": {
+    "hash": "sha256-qpvrP1xBV5Kd3rG0lHJC+2C1+/PV8d9G3pynsG2jeX8=",
+    "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.2.tgz"
+  },
+  "0.9.3": {
+    "hash": "sha256-gDevu+fPGSe7bwz58twqN9YMpjOKxf0bdLqDCuxmqig=",
+    "url": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.3.tgz"
   },
   "0.10.0": {
     "hash": "sha256-yDHOaOXNt+9SXfLUnymBZTSWMU5fkAFBxTTsl8lvzjM=",

--- a/manifests/spago.json
+++ b/manifests/spago.json
@@ -149,12 +149,80 @@
       "url": "https://github.com/purescript/spago/releases/download/0.21.0/macOS.tar.gz"
     }
   },
+  "0.93.0": {
+    "hash": "sha256-c82wJWd1HYEmsxzZP/0WRH72YlMBOmVNzQOC8pkjy4o=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.0.tgz"
+  },
+  "0.93.1": {
+    "hash": "sha256-cDDrSLzixj7BXxy/Em2b8Al+gWHwdR4NMytpB5bnwmA=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.1.tgz"
+  },
+  "0.93.2": {
+    "hash": "sha256-6bzTUHzWfO0VNdu2I653o/aynTCkyeDs3jlBpAw0aoA=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.2.tgz"
+  },
+  "0.93.3": {
+    "hash": "sha256-uvCAUG72hu2XbY+9Vxm1RMaHoIbmT1iLX6QB7Q8Yj8s=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.3.tgz"
+  },
+  "0.93.4": {
+    "hash": "sha256-Bkronfu/Ush1mJaHLu8pnSS06I6/3ltoKe+i5iPgft4=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.4.tgz"
+  },
+  "0.93.5": {
+    "hash": "sha256-Wyma1OzF6I80JPhso581qeNsExxpp7qUO4Mk/nuVJ4Y=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.5.tgz"
+  },
+  "0.93.6": {
+    "hash": "sha256-3nQrvQzI8Z1yWpICMHz6rFqlnHQis0iX5rqAa3mQ90o=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.6.tgz"
+  },
+  "0.93.7": {
+    "hash": "sha256-GBgHCRv91bxeiw84Dyy6WV8+Nuni4s+iEdefXaUH52c=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.7.tgz"
+  },
+  "0.93.8": {
+    "hash": "sha256-yz54k7lLITYqBt7oN+7f+tBTz7f03vGvNiIqfOuEaLk=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.8.tgz"
+  },
   "0.93.9": {
     "hash": "sha256-ewmsPhWlqF7e0mOc70M4+tzH8MvwhqsldTo/AsxHhP4=",
     "url": "https://registry.npmjs.org/spago/-/spago-0.93.9.tgz"
   },
+  "0.93.10": {
+    "hash": "sha256-G5RkHwOJJUBMvzCC5x8jKkn8EG5bpZk+9vqSdBs42bU=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.10.tgz"
+  },
+  "0.93.11": {
+    "hash": "sha256-yWUH04IRqn0uig493nBfmjdmOX3jlTGJF+8c4W4a6rY=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.11.tgz"
+  },
+  "0.93.12": {
+    "hash": "sha256-lZZjdh1/VQBmedJF/eob71C27ESLsBPJU4DG0PwxvIY=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.12.tgz"
+  },
+  "0.93.13": {
+    "hash": "sha256-A5KMOVlLeETuvzJNLjgDHuvK6pogZmdv4rIfib8zncE=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.13.tgz"
+  },
   "0.93.14": {
     "hash": "sha256-fdV25Iuv4fwLSdPaq+/iuThCirl6zeFbkXgg+cMQC6U=",
     "url": "https://registry.npmjs.org/spago/-/spago-0.93.14.tgz"
+  },
+  "0.93.15": {
+    "hash": "sha256-Rk1cNhCmJIdOecjLy8pmbFZWnc62QoNUYsPkZO6VdT8=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.15.tgz"
+  },
+  "0.93.16": {
+    "hash": "sha256-eHh/+iKPSO6WS72meJmpdcwlgvhAyK+/6s+Eay35NOU=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.16.tgz"
+  },
+  "0.93.17": {
+    "hash": "sha256-ZBDPxh3xQXk7BJK+YDWgcTvQWj/4JUPLiHdt3DzU0VU=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.17.tgz"
+  },
+  "0.93.18": {
+    "hash": "sha256-4njqpauwKFtHqhoRIrS9HWhhWBQCCchXY1Z8jbaO6JE=",
+    "url": "https://registry.npmjs.org/spago/-/spago-0.93.18.tgz"
   }
 }

--- a/manifests/spago.json
+++ b/manifests/spago.json
@@ -177,10 +177,6 @@
     "hash": "sha256-3nQrvQzI8Z1yWpICMHz6rFqlnHQis0iX5rqAa3mQ90o=",
     "url": "https://registry.npmjs.org/spago/-/spago-0.93.6.tgz"
   },
-  "0.93.7": {
-    "hash": "sha256-GBgHCRv91bxeiw84Dyy6WV8+Nuni4s+iEdefXaUH52c=",
-    "url": "https://registry.npmjs.org/spago/-/spago-0.93.7.tgz"
-  },
   "0.93.8": {
     "hash": "sha256-yz54k7lLITYqBt7oN+7f+tBTz7f03vGvNiIqfOuEaLk=",
     "url": "https://registry.npmjs.org/spago/-/spago-0.93.8.tgz"

--- a/manifests/spago.json
+++ b/manifests/spago.json
@@ -205,41 +205,22 @@
     "hash": "sha256-fdV25Iuv4fwLSdPaq+/iuThCirl6zeFbkXgg+cMQC6U=",
     "url": "https://registry.npmjs.org/spago/-/spago-0.93.14.tgz"
   },
-  "0.93.15": {
-    "lockfile": {
-      "hash": "sha256-crDdMZm5h2JWvl9PWKY2CkZbLFUizgiG9knSBsA8swY=",
-      "url": "https://raw.githubusercontent.com/purescript/spago/d805ec5b2d361e87013b92202f9e342eaf7c4e85/package-lock.json"
-    },
-    "tarball": {
-      "hash": "sha256-Rk1cNhCmJIdOecjLy8pmbFZWnc62QoNUYsPkZO6VdT8=",
-      "url": "https://registry.npmjs.org/spago/-/spago-0.93.15.tgz"
-    }
-  },
   "0.93.16": {
-    "lockfile": {
-      "hash": "sha256-+Nb4erLd45ANOnIj1CAWlOiQ/sxBz7Vl5CgoIf7+SI4=",
-      "url": "https://raw.githubusercontent.com/purescript/spago/29cd3cad10e0b2dca093ade0a7a2d114186002ba/package-lock.json"
-    },
+    "lockfile": "spago/better-sqlite3-8_6_0.json",
     "tarball": {
       "hash": "sha256-eHh/+iKPSO6WS72meJmpdcwlgvhAyK+/6s+Eay35NOU=",
       "url": "https://registry.npmjs.org/spago/-/spago-0.93.16.tgz"
     }
   },
   "0.93.17": {
-    "lockfile": {
-      "hash": "sha256-+Nb4erLd45ANOnIj1CAWlOiQ/sxBz7Vl5CgoIf7+SI4=",
-      "url": "https://raw.githubusercontent.com/purescript/spago/29cd3cad10e0b2dca093ade0a7a2d114186002ba/package-lock.json"
-    },
+    "lockfile": "spago/better-sqlite3-8_6_0.json",
     "tarball": {
       "hash": "sha256-ZBDPxh3xQXk7BJK+YDWgcTvQWj/4JUPLiHdt3DzU0VU=",
       "url": "https://registry.npmjs.org/spago/-/spago-0.93.17.tgz"
     }
   },
   "0.93.18": {
-    "lockfile": {
-      "hash": "sha256-UgdxJGxNOy35VQ4OghIHcqklCEXtl1wOKjD3MrqFvuY=",
-      "url": "https://raw.githubusercontent.com/purescript/spago/8bc78b4d7ca57c613685635a06ba31249321abeb/package-lock.json"
-    },
+    "lockfile": "spago/better-sqlite3-8_6_0.json",
     "tarball": {
       "hash": "sha256-4njqpauwKFtHqhoRIrS9HWhhWBQCCchXY1Z8jbaO6JE=",
       "url": "https://registry.npmjs.org/spago/-/spago-0.93.18.tgz"

--- a/manifests/spago.json
+++ b/manifests/spago.json
@@ -206,19 +206,43 @@
     "url": "https://registry.npmjs.org/spago/-/spago-0.93.14.tgz"
   },
   "0.93.15": {
-    "hash": "sha256-Rk1cNhCmJIdOecjLy8pmbFZWnc62QoNUYsPkZO6VdT8=",
-    "url": "https://registry.npmjs.org/spago/-/spago-0.93.15.tgz"
+    "lockfile": {
+      "hash": "sha256-crDdMZm5h2JWvl9PWKY2CkZbLFUizgiG9knSBsA8swY=",
+      "url": "https://raw.githubusercontent.com/purescript/spago/d805ec5b2d361e87013b92202f9e342eaf7c4e85/package-lock.json"
+    },
+    "tarball": {
+      "hash": "sha256-Rk1cNhCmJIdOecjLy8pmbFZWnc62QoNUYsPkZO6VdT8=",
+      "url": "https://registry.npmjs.org/spago/-/spago-0.93.15.tgz"
+    }
   },
   "0.93.16": {
-    "hash": "sha256-eHh/+iKPSO6WS72meJmpdcwlgvhAyK+/6s+Eay35NOU=",
-    "url": "https://registry.npmjs.org/spago/-/spago-0.93.16.tgz"
+    "lockfile": {
+      "hash": "sha256-+Nb4erLd45ANOnIj1CAWlOiQ/sxBz7Vl5CgoIf7+SI4=",
+      "url": "https://raw.githubusercontent.com/purescript/spago/29cd3cad10e0b2dca093ade0a7a2d114186002ba/package-lock.json"
+    },
+    "tarball": {
+      "hash": "sha256-eHh/+iKPSO6WS72meJmpdcwlgvhAyK+/6s+Eay35NOU=",
+      "url": "https://registry.npmjs.org/spago/-/spago-0.93.16.tgz"
+    }
   },
   "0.93.17": {
-    "hash": "sha256-ZBDPxh3xQXk7BJK+YDWgcTvQWj/4JUPLiHdt3DzU0VU=",
-    "url": "https://registry.npmjs.org/spago/-/spago-0.93.17.tgz"
+    "lockfile": {
+      "hash": "sha256-+Nb4erLd45ANOnIj1CAWlOiQ/sxBz7Vl5CgoIf7+SI4=",
+      "url": "https://raw.githubusercontent.com/purescript/spago/29cd3cad10e0b2dca093ade0a7a2d114186002ba/package-lock.json"
+    },
+    "tarball": {
+      "hash": "sha256-ZBDPxh3xQXk7BJK+YDWgcTvQWj/4JUPLiHdt3DzU0VU=",
+      "url": "https://registry.npmjs.org/spago/-/spago-0.93.17.tgz"
+    }
   },
   "0.93.18": {
-    "hash": "sha256-4njqpauwKFtHqhoRIrS9HWhhWBQCCchXY1Z8jbaO6JE=",
-    "url": "https://registry.npmjs.org/spago/-/spago-0.93.18.tgz"
+    "lockfile": {
+      "hash": "sha256-UgdxJGxNOy35VQ4OghIHcqklCEXtl1wOKjD3MrqFvuY=",
+      "url": "https://raw.githubusercontent.com/purescript/spago/8bc78b4d7ca57c613685635a06ba31249321abeb/package-lock.json"
+    },
+    "tarball": {
+      "hash": "sha256-4njqpauwKFtHqhoRIrS9HWhhWBQCCchXY1Z8jbaO6JE=",
+      "url": "https://registry.npmjs.org/spago/-/spago-0.93.18.tgz"
+    }
   }
 }

--- a/manifests/spago.json
+++ b/manifests/spago.json
@@ -218,12 +218,5 @@
       "hash": "sha256-ZBDPxh3xQXk7BJK+YDWgcTvQWj/4JUPLiHdt3DzU0VU=",
       "url": "https://registry.npmjs.org/spago/-/spago-0.93.17.tgz"
     }
-  },
-  "0.93.18": {
-    "lockfile": "spago/better-sqlite3-8_6_0.json",
-    "tarball": {
-      "hash": "sha256-4njqpauwKFtHqhoRIrS9HWhhWBQCCchXY1Z8jbaO6JE=",
-      "url": "https://registry.npmjs.org/spago/-/spago-0.93.18.tgz"
-    }
   }
 }


### PR DESCRIPTION
This resumes auto-updates for spago@next and fixes #47. Spago versions from 0.93.15 onward do not bundle better-sqlite3, so this update includes that dependency in the node_modules directory for the spago build from 0.93.15 forward.

This is quite brittle; if the version of better-sqlite3 changes or other dependencies are excluded from the bundle then the derivations here will need to be manually updated.

I plan to come back and rewrite some of this code later on to be a bit better, but I don't have time for it at the moment. In the meantime we at least have (brittle) updates for spago@next.