### PR TITLE
Test support

### DIFF
--- a/generate/default.nix
+++ b/generate/default.nix
@@ -13,8 +13,7 @@
   purs-backend-es,
   purs-tidy,
 }: let
-  npmDependencies = slimlock.buildPackageLock {src = ./.;};
-  packages = purix.buildSpagoLock {
+  locked = purix.buildSpagoLock {
     src = ./.;
     corefn = true;
   };
@@ -30,8 +29,8 @@ in
     buildInputs = [prefetch-npm-deps];
 
     buildPhase = ''
-      ln -s ${npmDependencies}/js/node_modules .
-      cp -r ${packages.${name}}/output .
+      ln -s ${locked.npmDependencies}/js/node_modules .
+      cp -r ${locked.jsArtifacts.${name}}/output .
       set -f
       echo "Optimizing..."
       purs-backend-es build

--- a/generate/default.nix
+++ b/generate/default.nix
@@ -13,6 +13,7 @@
   purs-backend-es,
   purs-tidy,
 }: let
+  npmDependencies = slimlock.buildPackageLock {src = ./.;} + "/js/node_modules";
   locked = purix.buildSpagoLock {
     src = ./.;
     corefn = true;
@@ -29,8 +30,8 @@ in
     buildInputs = [prefetch-npm-deps];
 
     buildPhase = ''
-      ln -s ${locked.npmDependencies}/js/node_modules .
-      cp -r ${locked.jsArtifacts.${name}}/output .
+      ln -s ${npmDependencies} .
+      cp -r ${locked.${name}}/output .
       set -f
       echo "Optimizing..."
       purs-backend-es build

--- a/nix/build-spago-lock.nix
+++ b/nix/build-spago-lock.nix
@@ -338,7 +338,7 @@
                     purs compile ${lib.concatStringsSep " " testGlobs} --codegen js 2>&1
                     set +f
                     ${
-                      # Only simplink if the package-lock.json existsts.
+                      # Only symlink if the package-lock.json exists.
                       if builtins.pathExists "${src}/package-lock.json"
                       then ''
                         echo "Symlinking node modules..."

--- a/nix/build-spago-lock.nix
+++ b/nix/build-spago-lock.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  slimlock,
   lib,
   fetchurl,
   fetchgit,
@@ -21,13 +22,16 @@
 
   # Read a package listed in the lockfile
   readLockedPackage = src: name: attr:
-    if attr.type == "registry"
-    then readRegistryPackage name attr
-    else if attr.type == "git"
-    then readGitPackage name attr
-    else if attr.type == "local"
-    then readLocalPackage src name attr
-    else throw "Unknown package type ${attr.type}";
+    (
+      if attr.type == "registry"
+      then readRegistryPackage name attr
+      else if attr.type == "git"
+      then readGitPackage name attr
+      else if attr.type == "local"
+      then readLocalPackage src name attr
+      else throw "Unknown package type ${attr.type}"
+    )
+    // {fromWorkspace = false;};
 
   # Option 1: Fetch and unpack the given package from the registry
   # "effect": {
@@ -39,7 +43,7 @@
     stdenv.mkDerivation {
       name = name;
       version = attr.version;
-      dependencies = attr.dependencies;
+      depNames = attr.dependencies;
 
       src = fetchurl {
         name = "${name}-${attr.version}.tar.gz";
@@ -68,7 +72,7 @@
   in
     stdenv.mkDerivation {
       name = name;
-      dependencies = attr.dependencies;
+      depNames = attr.dependencies;
       src =
         if builtins.hasAttr "subdir" attr
         then "${fetched}/${attr.subdir}"
@@ -86,7 +90,7 @@
   readLocalPackage = src: name: attr:
     stdenv.mkDerivation {
       name = name;
-      dependencies = attr.dependencies;
+      depNames = attr.dependencies;
       src = pathExists "${src}/${attr.path}";
       installPhase = ''
         cp -R . "$out"
@@ -99,22 +103,29 @@
 
   # Read a workspace package. These are listed at the top of the
   # lockfile, not in the main packages list.
-  readWorkspacePackage = src: extraSrcs: name: attr:
+  readWorkspacePackage = src: extraSrcs: name: attr: let
+    toNames = dep:
+      if builtins.typeOf dep == "set"
+      then lib.attrNames dep
+      else [dep];
+  in
     stdenv.mkDerivation {
       name = name;
+
       # The workspace packages list version ranges with their dependencies, so
       # we want to take only the keys.
-      dependencies = let
-        toNames = dep:
-          if builtins.typeOf dep == "set"
-          then lib.attrNames dep
-          else [dep];
-      in
-        lib.concatMap toNames attr.dependencies;
+      depNames = lib.concatMap toNames attr.dependencies;
+
+      testDepNames =
+        if attr ? test_dependencies
+        then lib.concatMap toNames attr.test_dependencies
+        else {};
+
       src =
         if attr.path == "./"
         then src
         else pathExists "${src}/${attr.path}";
+
       installPhase = ''
         cp -R . $out
         ${
@@ -128,6 +139,8 @@
           ''
         }
       '';
+
+      fromWorkspace = true;
     };
 
   # Read the workspace packages
@@ -153,6 +166,9 @@
   # not to rebuild them.
   mergeCacheDb = deps: ''
     caches=()
+    if [ -f output/cache-db.json ]; then
+      caches+="output/cache-db.json "
+    fi
     for dir in ${lib.concatStringsSep " " deps}
     do
       caches+="$dir/output/cache-db.json "
@@ -164,136 +180,185 @@
   fixDependencies = {
     purs,
     corefn,
-  }: deps:
-    lib.fix (self:
-      lib.mapAttrs (name: drv: let
-        get-dep = dep: self.${dep};
-
-        directs = builtins.listToAttrs (map (name: {
+    tests,
+    npmDependencies,
+  }: spagoPkgs:
+    lib.fix (
+      self:
+        lib.mapAttrs (name: spagoPkg: let
+          depNameToAttr = name: {
             name = name;
-            value = get-dep name;
-          })
-          drv.dependencies);
-
-        transitive = builtins.foldl' (a: pkg: a // self.${pkg}.dependencies) {} drv.dependencies;
-
-        dependencies = transitive // directs;
-
-        defaultVersion = "0.0.0";
-
-        version =
-          drv.version
-          or (
-            if builtins.pathExists "${drv.out}/spago.yaml"
-            then lib.attrByPath ["package" "publish" "version"] defaultVersion (fromYAML (builtins.readFile "${drv.out}/spago.yaml"))
-            else defaultVersion
-          );
-
-        # FIXME hack to provide spago and spago-bin with spagoVersion
-        dependenciesList =
-          lib.attrValues dependencies
-          ++ [
-            {
-              name = "spago-bin";
-              version = version;
-            }
-          ];
-
-        renderPackageType = p: ''"${p.name}" :: String'';
-        packagesType = "{ ${lib.concatMapStringsSep ", " renderPackageType dependenciesList} }";
-        renderPackage = p: ''"${p.name}": "${p.version or defaultVersion}"'';
-        packages = ''{ ${lib.concatMapStringsSep "\n  , " renderPackage dependenciesList} }'';
-      in
-        stdenv.mkDerivation rec {
-          name = drv.name;
-
-          src = drv.out;
-
-          inherit version;
-
-          nativeBuildInputs = [purs jq];
-
-          phases = ["buildPhase" "installPhase" "checkPhase"];
-
-          passthru = {
-            inherit dependencies;
+            value = self.${name};
           };
 
-          # TODO: The 'files' key can indicate additional deps.
-          globs =
-            ["${src}/src/**/*.purs"]
-            ++ map (dep: ''"${dep.src}/src/**/*.purs"'') (builtins.attrValues dependencies);
+          makeTransitiveDeps = builtins.foldl' (a: depName: a // self.${depName}.deps) {};
 
-          # This is bad...but without Spago, how else can we get this?
-          buildInfo = pkgs.writeText "BuildInfo.purs" ''
-            -- @inline export packages always
-            -- @inline export pursVersion always
-            -- @inline export spagoVersion always
-            module Spago.Generated.BuildInfo where
+          directs = builtins.listToAttrs (map depNameToAttr spagoPkg.depNames);
 
-            packages :: ${packagesType}
-            packages = ${packages}
+          transitive = makeTransitiveDeps spagoPkg.depNames;
 
-            pursVersion :: String
-            pursVersion = "${purs.version}"
+          deps = transitive // directs;
 
-            spagoVersion :: String
-            spagoVersion = "${version}"
-          '';
+          defaultVersion = "0.0.0";
 
-          preBuild = ''
-            mkdir output
-            echo "Fetching dependencies..."
-            ${syncOutput (builtins.attrValues directs)}
-            echo "Merge cache-db.json files..."
-            ${mergeCacheDb (builtins.attrValues directs)}
-          '';
+          version =
+            spagoPkg.version
+            or (
+              if builtins.pathExists "${spagoPkg.out}/spago.yaml"
+              then lib.attrByPath ["package" "publish" "version"] defaultVersion (fromYAML (builtins.readFile "${spagoPkg.out}/spago.yaml"))
+              else defaultVersion
+            );
 
-          buildPhase = ''
-            runHook preBuild
+          # FIXME hack to provide spago and spago-bin with spagoVersion
+          depsList =
+            lib.attrValues deps
+            ++ [
+              {
+                name = "spago-bin";
+                version = version;
+              }
+            ];
 
-            cleanup() {
-              exit_code=$?
-              if [ $exit_code -ne 0 ]; then
-                echo "purs compile failed with exit code $exit_code."
+          renderPackageType = p: ''"${p.name}" :: String'';
+          packagesType = "{ ${lib.concatMapStringsSep ", " renderPackageType depsList} }";
+          renderPackage = p: ''"${p.name}": "${p.version or defaultVersion}"'';
+          packages = ''{ ${lib.concatMapStringsSep "\n  , " renderPackage depsList} }'';
+        in
+          stdenv.mkDerivation rec {
+            name = spagoPkg.name;
+
+            src = spagoPkg.out;
+
+            inherit version;
+
+            nativeBuildInputs =
+              [purs jq]
+              # Nodejs is only needed if there is a tested package.
+              ++ (
+                if runSpagoTests
+                then [pkgs.nodejs]
+                else []
+              );
+
+            phases = ["buildPhase" "installPhase" "checkPhase"];
+
+            passthru = {
+              inherit deps;
+            };
+
+            # TODO: The 'files' key can indicate additional deps.
+            globs =
+              ["${src}/src/**/*.purs"]
+              ++ map (dep: ''"${dep.src}/src/**/*.purs"'') (builtins.attrValues deps);
+
+            # This is bad...but without Spago, how else can we get this?
+            buildInfo = pkgs.writeText "BuildInfo.purs" ''
+              -- @inline export packages always
+              -- @inline export pursVersion always
+              -- @inline export spagoVersion always
+              module Spago.Generated.BuildInfo where
+
+              packages :: ${packagesType}
+              packages = ${packages}
+
+              pursVersion :: String
+              pursVersion = "${purs.version}"
+
+              spagoVersion :: String
+              spagoVersion = "${version}"
+            '';
+
+            preBuild = ''
+              mkdir output
+              echo "Fetching dependencies..."
+              ${syncOutput (builtins.attrValues directs)}
+              echo "Merge cache-db.json files..."
+              ${mergeCacheDb (builtins.attrValues directs)}
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+
+              cleanup() {
+                exit_code=$?
+                if [ $exit_code -ne 0 ]; then
+                  echo "purs compile failed with exit code $exit_code."
+                  cat purs-log.txt
+                fi
+                exit $exit_code
+              }
+
+              trap cleanup EXIT
+              # TODO: Ideally we would only compile to corefn if we know it's
+              # necessary (for example, a 'backend' command was supplied).
+              set -f
+              purs compile ${lib.concatStringsSep " " globs} ${buildInfo} --codegen js${
+                if corefn
+                then ",corefn"
+                else ""
+              } 2>&1 | tee purs-log.txt
+              set +f
+
+              # Cancel trap.
+              trap - EXIT
+            '';
+
+            installPhase = ''
+              mkdir $out
+              cp -r output $out
+            '';
+
+            runSpagoTests = spagoPkg.fromWorkspace && builtins.hasAttr spagoPkg.name tests;
+
+            doCheck = true;
+            checkPhase = ''
+              # The +1 is for the BuildInfo.purs file.
+              FILE_COUNT=$(($(find ${src}/src -name '*.purs' | wc -l) + 1))
+              COMPILE_LINE=$(grep -m 1 "^\[[0-9]* of [0-9]*\] Compiling" purs-log.txt)
+              MODULE_COUNT=$(echo $COMPILE_LINE | sed -n 's/^\[\([0-9]*\) of \([0-9]*\)\] Compiling.*$/\2/p')
+              if [[ $FILE_COUNT -ne $MODULE_COUNT ]]; then
+                echo ".purs file count ($FILE_COUNT) does not match the module count ($MODULE_COUNT)."
+                echo "This indicates incremental compilation is wrong."
                 cat purs-log.txt
+                exit 1
               fi
-              exit $exit_code
-            }
+              ${
+                let
+                  testDepNames = spagoPkg.testDepNames or [];
+                  directTestDeps = builtins.listToAttrs (map depNameToAttr testDepNames);
+                  transitiveTestDeps = makeTransitiveDeps testDepNames;
+                  testDeps = transitiveTestDeps // directTestDeps;
+                  testGlobs =
+                    globs
+                    ++ ["${src}/test/**/*.purs"]
+                    ++ map (dep: ''"${dep.src}/src/**/*.purs"'') (builtins.attrValues testDeps);
 
-            trap cleanup EXIT
-
-            # TODO: Ideally we would only compile to corefn if we know it's
-            # necessary (for example, a 'backend' command was supplied).
-            set -f
-            purs compile ${lib.concatStringsSep " " globs} ${buildInfo} --codegen js${
-              if corefn
-              then ",corefn"
-              else ""
-            } 2>&1 | tee purs-log.txt
-            set +f
-          '';
-
-          installPhase = ''
-            mkdir $out
-            mv output $out/output
-          '';
-
-          # We can add tests here, but they're off by default.
-          doCheck = false;
-          checkPhase = ''
-            FILE_COUNT=$(find ${src}/src -name '*.purs' | wc -l)
-            COMPILE_LINE=$(grep -m 1 "^\[[0-9]* of [0-9]*\] Compiling" purs-log.txt)
-            MODULE_COUNT=$(echo $COMPILE_LINE | sed -n 's/^\[\([0-9]*\) of \([0-9]*\)\] Compiling.*$/\2/p')
-            if [[ $FILE_COUNT -ne $MODULE_COUNT ]]; then
-              echo ".purs file count ($FILE_COUNT) does not match the module count ($MODULE_COUNT)."
-              echo "This indicates incremental compilation is wrong."
-              cat purs-log.txt
-              exit 1
-            fi
-          '';
-        })
-      deps);
+                  spagoTestCommands = ''
+                    echo "Compiling tests..."
+                    set -f
+                    purs compile ${lib.concatStringsSep " " testGlobs} --codegen js 2>&1
+                    set +f
+                    ${
+                      # Only simplink if the package-lock.json existsts.
+                      if builtins.pathExists "${src}/package-lock.json"
+                      then ''
+                        echo "Symlinking node modules..."
+                        ln -s ${npmDependencies}/js/node_modules .
+                      ''
+                      else "echo 'No package-lock.json found in ${src}. Skipping symlinking.'"
+                    }
+                    # Generate test_entrypoint.mjs.
+                    echo "import { main } from './output/${tests."${spagoPkg.name}"}/index.js'; main();" > test_entrypoint.mjs
+                    echo "Running tests..."
+                    node test_entrypoint.mjs
+                  '';
+                in
+                  lib.optionalString runSpagoTests spagoTestCommands
+              }
+            '';
+          })
+        spagoPkgs
+    );
 
   buildSpagoLock = {
     src,
@@ -305,15 +370,32 @@
     #
     # Non-existent packages are silently ignored.
     extraSrcs ? {},
-  }: let
-    lock = readSpagoLock lockfile;
-    workspaceDirs = builtins.attrValues (lib.mapAttrs (_: attr: attr.path) lock.workspace.packages);
-    # We only want to include the lockfile and code from any listed workspaces
-    filteredSrc = lib.cleanSourceWith {
-      filter = name: type: name != "spago.lock" && !(builtins.elem name workspaceDirs);
-      src = lib.cleanSource src;
+    # A record from a name of a spago package in this workspace to the name of its test module.
+    #
+    # Non-existent packages are silently ignored.
+    #
+    # TODO: Don't require the user to pass the name of the main module of the test. It is in
+    # stack.yaml, but we don't have a way to parse that yet.
+    tests ? {},
+  }:
+    assert lib.assertMsg (builtins.isAttrs extraSrcs)
+    "argument `extraSrcs` to `buildSpagoLock` must be a set";
+    assert lib.assertMsg (builtins.isAttrs tests)
+    "argument `tests` to `buildSpagoLock` must be a set"; let
+      lock = readSpagoLock lockfile;
+      workspaceDirs =
+        builtins.attrValues (lib.mapAttrs (_: attr: attr.path) lock.workspace.packages);
+      # We only want to include the lockfile and code from any listed workspaces
+      cleanSrc = lib.cleanSource src;
+      filteredSrc = lib.cleanSourceWith {
+        filter = name: type: name != "spago.lock" && !(builtins.elem name workspaceDirs);
+        src = cleanSrc;
+      };
+    in rec
+    {
+      jsArtifacts =
+        fixDependencies {inherit purs corefn tests npmDependencies;}
+        (lockedPackages filteredSrc lock // workspacePackages filteredSrc extraSrcs lock);
+      npmDependencies = slimlock.buildPackageLock {src = cleanSrc;};
     };
-  in
-    fixDependencies {inherit purs corefn;}
-    (lockedPackages filteredSrc lock // workspacePackages filteredSrc extraSrcs lock);
 }

--- a/nix/examples/default.nix
+++ b/nix/examples/default.nix
@@ -4,4 +4,5 @@
   simple = callPackage ./simple {};
   simple-ffi = callPackage ./simple-ffi {};
   simple-codegen = callPackage ./simple-codegen {};
+  simple-tested = callPackage ./simple-tested {};
 }

--- a/nix/examples/simple-codegen/default.nix
+++ b/nix/examples/simple-codegen/default.nix
@@ -27,7 +27,7 @@ in
     src = ./.;
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${lock.jsArtifacts.simple-codegen}/output .
+      ln -s ${lock.simple-codegen}/output .
     '';
     installPhase = ''
       mkdir -p $out

--- a/nix/examples/simple-codegen/default.nix
+++ b/nix/examples/simple-codegen/default.nix
@@ -27,7 +27,7 @@ in
     src = ./.;
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${lock.simple-codegen}/output .
+      ln -s ${lock.jsArtifacts.simple-codegen}/output .
     '';
     installPhase = ''
       mkdir -p $out

--- a/nix/examples/simple-ffi/default.nix
+++ b/nix/examples/simple-ffi/default.nix
@@ -2,10 +2,15 @@
   stdenv,
   writeText,
   esbuild,
+  slimlock,
   purix,
   purs-bin,
 }: let
-  locked = purix.buildSpagoLock {src = ./.;};
+  npmDependencies = slimlock.buildPackageLock {src = ./.;} + "/js/node_modules";
+  locked = purix.buildSpagoLock {
+    src = ./.;
+    inherit npmDependencies;
+  };
   entrypoint = writeText "entrypoint.js" ''
     import { main } from "./output/Main";
     main();
@@ -17,8 +22,8 @@ in
     nativeBuildInputs = [purs-bin.purs-0_15_9 esbuild];
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${locked.npmDependencies}/js/node_modules .
-      cp -r ${locked.jsArtifacts.simple-ffi}/output .
+      ln -s ${npmDependencies} .
+      cp -r ${locked.simple-ffi}/output .
       cp ${entrypoint} entrypoint.js
       cat entrypoint.js
       esbuild entrypoint.js \

--- a/nix/examples/simple-ffi/default.nix
+++ b/nix/examples/simple-ffi/default.nix
@@ -2,12 +2,10 @@
   stdenv,
   writeText,
   esbuild,
-  slimlock,
   purix,
   purs-bin,
 }: let
-  packageLock = slimlock.buildPackageLock {src = ./.;};
-  spagoLock = purix.buildSpagoLock {src = ./.;};
+  locked = purix.buildSpagoLock {src = ./.;};
   entrypoint = writeText "entrypoint.js" ''
     import { main } from "./output/Main";
     main();
@@ -19,8 +17,8 @@ in
     nativeBuildInputs = [purs-bin.purs-0_15_9 esbuild];
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${packageLock}/js/node_modules .
-      cp -r ${spagoLock.simple-ffi}/output .
+      ln -s ${locked.npmDependencies}/js/node_modules .
+      cp -r ${locked.jsArtifacts.simple-ffi}/output .
       cp ${entrypoint} entrypoint.js
       cat entrypoint.js
       esbuild entrypoint.js \

--- a/nix/examples/simple-tested/default.nix
+++ b/nix/examples/simple-tested/default.nix
@@ -1,11 +1,13 @@
 {
   stdenv,
   purix,
+  slimlock,
 }: let
   locked = purix.buildSpagoLock {
     src = ./.;
     lockfile = ./spago.lock;
     tests.simple-tested = "Example.Simple.Tested.Tests";
+    npmDependencies = slimlock.buildPackageLock {src = ./.;} + "/js/node_modules";
   };
 in
   stdenv.mkDerivation {
@@ -13,7 +15,7 @@ in
     src = ./.;
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${locked.jsArtifacts.simple-tested}/output .
+      ln -s ${locked.simple-tested}/output .
     '';
     installPhase = ''
       mkdir -p $out

--- a/nix/examples/simple-tested/default.nix
+++ b/nix/examples/simple-tested/default.nix
@@ -5,6 +5,7 @@
   locked = purix.buildSpagoLock {
     src = ./.;
     lockfile = ./spago.lock;
+    tests.simple-tested = "Example.Simple.Tested.Tests";
   };
 in
   stdenv.mkDerivation {
@@ -12,7 +13,7 @@ in
     src = ./.;
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${locked.jsArtifacts.simple}/output .
+      ln -s ${locked.jsArtifacts.simple-tested}/output .
     '';
     installPhase = ''
       mkdir -p $out

--- a/nix/examples/simple-tested/package-lock.json
+++ b/nix/examples/simple-tested/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "simple-tested",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simple-tested",
+      "version": "1.0.0",
+      "dependencies": {
+        "decimal.js": "^10.4.3"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    }
+  }
+}

--- a/nix/examples/simple-tested/package.json
+++ b/nix/examples/simple-tested/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "simple-tested",
+  "version": "1.0.0",
+  "dependencies": {
+    "decimal.js": "^10.4.3"
+  }
+}

--- a/nix/examples/simple-tested/spago.lock
+++ b/nix/examples/simple-tested/spago.lock
@@ -1,0 +1,1312 @@
+workspace:
+  packages:
+    simple-tested:
+      path: ./
+      dependencies:
+        - decimals
+        - prelude
+      test_dependencies:
+        - spec-discovery
+        - spec-quickcheck
+      build_plan:
+        - aff
+        - aff-promise
+        - ansi
+        - arraybuffer-types
+        - arrays
+        - avar
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - decimals
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - foreign
+        - fork
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-date
+        - lazy
+        - lcg
+        - lists
+        - maybe
+        - mmorph
+        - newtype
+        - node-buffer
+        - node-fs
+        - node-path
+        - node-streams
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - pipes
+        - prelude
+        - profunctor
+        - quickcheck
+        - random
+        - record
+        - refs
+        - safe-coerce
+        - spec
+        - spec-discovery
+        - spec-quickcheck
+        - st
+        - strings
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+  package_set:
+    address:
+      registry: 25.2.1
+    compiler: ">=0.15.8 <0.16.0"
+    content:
+      abc-parser: 2.0.0
+      ace: 9.1.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      array-search: 0.5.6
+      arraybuffer: 13.2.0
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.2.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      assert-multiple: 0.3.4
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      basic-auth: 3.0.1
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.9
+      bookhound: 0.1.2
+      bower-json: 3.0.0
+      bucketchain: 1.0.1
+      bucketchain-basic-auth: 1.0.1
+      bucketchain-conditional: 1.0.1
+      bucketchain-cors: 1.0.1
+      bucketchain-csrf: 1.0.1
+      bucketchain-header-utils: 1.0.1
+      bucketchain-health: 1.0.1
+      bucketchain-history-api-fallback: 1.0.1
+      bucketchain-logger: 1.0.1
+      bucketchain-secure: 1.0.1
+      bucketchain-simple-api: 5.0.1
+      bucketchain-sslify: 1.0.1
+      bucketchain-static: 1.0.1
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      crypto: 5.0.1
+      css: 6.0.0
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.22
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dodo-printer: 2.2.1
+      dom-filereader: 7.0.0
+      dom-indexed: 11.0.0
+      dotenv: 4.0.0
+      droplet: 0.6.0
+      dts: 0.1.4
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.9.3
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.8.1
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      env-names: 0.3.4
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 1.1.4
+      fetch-argonaut: 1.0.1
+      fetch-core: 4.0.4
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.3.0
+      float32: 2.0.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      forgetmenot: 0.1.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.0.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geojson: 0.0.3
+      geometry-plane: 1.0.3
+      github-actions-toolkit: 0.5.0
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphql-client: 9.3.2
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.2.0
+      halogen-css: 10.0.0
+      halogen-css-frameworks: 1.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.3
+      halogen-helix: 1.0.0
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 8.0.0
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpure: 0.16.0
+      httpurple: 3.0.1
+      httpurple-argonaut: 1.0.1
+      httpurple-yoga-json: 1.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.8
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-db: 1.0.0
+      indexed-monad: 3.0.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.10.0
+      jelly-router: 0.3.0
+      jelly-signal: 0.4.0
+      jest: 1.0.0
+      js-abort-controller: 1.0.0
+      js-bigints: 2.1.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-iterators: 0.1.1
+      js-maps: 0.1.2
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      json-codecs: 3.0.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      labeled-data: 0.2.0
+      language-cst-parser: 0.13.0
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      liminal: 1.0.1
+      linalg: 6.0.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      maps-eager: 0.4.1
+      marionette: 1.0.0
+      marionette-commander: 0.1.1
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      mdast-util-from-markdown: 0.2.1
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      nanoid: 0.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextjs: 0.1.1
+      nextui: 0.2.0
+      node-buffer: 8.0.0
+      node-buffer-blob: 1.0.0
+      node-child-process: 9.0.0
+      node-env-paths: 1.0.0
+      node-event-emitter: 1.0.1
+      node-execa: 2.0.0
+      node-fs: 8.2.0
+      node-fs-aff: 9.2.0
+      node-http: 8.0.0
+      node-human-signals: 1.0.0
+      node-net: 4.0.0
+      node-os: 4.0.0
+      node-path: 5.0.0
+      node-process: 10.0.0
+      node-readline: 7.0.0
+      node-sqlite3: 8.0.0
+      node-streams: 7.0.0
+      node-streams-aff: 5.0.0
+      node-url: 6.0.0
+      nodemailer: 4.0.1
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numberfield: 0.1.0
+      numbers: 9.0.1
+      oak: 3.1.0
+      object-maps: 0.3.0
+      ocarina: 1.5.4
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.0
+      ordered-collections: 3.0.0
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.1
+      parallel: 6.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.11.0
+      phaser: 0.7.0
+      phylio: 1.1.2
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      pmock: 0.4.0
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.3.0
+      ps-cst: 1.2.0
+      psa-utils: 8.0.0
+      psc-ide: 19.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.2.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 5.0.1
+      rdf: 0.1.0
+      react: 11.0.0
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.1.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.2.0
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.1.1
+      react-markdown: 0.1.0
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      recharts: 1.1.0
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.4
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-jwt: 4.0.1
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.3.0
+      sparse-polynomials: 2.0.5
+      spec: 7.3.0
+      spec-discovery: 8.0.1
+      spec-golden: 1.0.0
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      statistics: 0.3.2
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      sunde: 3.0.0
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.2.1
+      tecton-halogen: 0.2.0
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      toppokki: 4.0.0
+      transformation-matrix: 1.0.1
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      ts-bridge: 2.0.3
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typedenv: 2.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unique: 0.6.1
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      variant-encodings: 2.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-cssom-view: 0.1.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 3.0.0
+      web-file: 4.0.0
+      web-geometry: 0.1.0
+      web-html: 4.1.0
+      web-intl: 0.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.1.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 3.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.1
+      webextension-polyfill: 0.1.0
+      webgpu: 0.0.0
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 5.1.0
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
+      z3: 0.0.2
+  extra_packages: {}
+packages:
+  aff:
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
+    dependencies:
+      - arrays
+      - bifunctors
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - functions
+      - maybe
+      - newtype
+      - parallel
+      - prelude
+      - refs
+      - tailrec
+      - transformers
+      - unsafe-coerce
+  aff-promise:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Kq5EupbUpXeUXx4JqGQE7/RTTz/H6idzWhsocwlEFhM=
+    dependencies:
+      - aff
+      - foreign
+  ansi:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-ZMB6HD+q9CXvn9fRCmJ8dvuDrOVHcjombL3oNOerVnE=
+    dependencies:
+      - foldable-traversable
+      - lists
+      - strings
+  arraybuffer-types:
+    type: registry
+    version: 3.0.2
+    integrity: sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=
+    dependencies: []
+  arrays:
+    type: registry
+    version: 7.2.0
+    integrity: sha256-vjd5tY1VFIg3HGBUFqG9+tWXqkV3EHRqZCzE+JC2yR0=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - safe-coerce
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  bifunctors:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  decimals:
+    type: registry
+    version: 7.1.0
+    integrity: sha256-DriR6lPEfFpjVv7e4JAQkr3ZLf0h17Qg2cAIrhxWV7w=
+    dependencies:
+      - maybe
+  distributive:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
+    dependencies:
+      - prelude
+  either:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  fork:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-X7u0SuCvFbLbzuNEKLBNuWjmcroqMqit4xEzpQwAP7E=
+    dependencies:
+      - aff
+  free:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-72auTIZAG6fhz4F94rxyDwgfnHwp+/89rujZpZWrV0w=
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
+    dependencies:
+      - prelude
+  functors:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  lazy:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lcg:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=
+    dependencies:
+      - effect
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - random
+  lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  mmorph:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-urZlZNNqGeQFe5D/ClHlR8QgGBNHTMFPtJ5S5IpflTQ=
+    dependencies:
+      - free
+      - functors
+      - transformers
+  newtype:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
+    dependencies:
+      - prelude
+      - safe-coerce
+  node-buffer:
+    type: registry
+    version: 8.0.0
+    integrity: sha256-RwOTB8yTS4Jjqc55JqxRcVaMXP+cYJ5aww0XH1Z/I8A=
+    dependencies:
+      - arraybuffer-types
+      - effect
+      - maybe
+      - st
+      - unsafe-coerce
+  node-fs:
+    type: registry
+    version: 8.2.0
+    integrity: sha256-6X/8KFH5qAF15UDrMadoyAMZxd08bs9IF2XrVgvpH2I=
+    dependencies:
+      - datetime
+      - effect
+      - either
+      - enums
+      - exceptions
+      - functions
+      - integers
+      - js-date
+      - maybe
+      - node-buffer
+      - node-path
+      - node-streams
+      - nullable
+      - partial
+      - prelude
+      - strings
+      - unsafe-coerce
+  node-path:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-pd82nQ+2l5UThzaxPdKttgDt7xlsgIDLpPG0yxDEdyE=
+    dependencies:
+      - effect
+  node-streams:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EGCA+hp6chlxDlQ8UG3RIaIIL1R0OckKnqP+KPAX1y4=
+    dependencies:
+      - effect
+      - either
+      - exceptions
+      - node-buffer
+      - nullable
+      - prelude
+  nonempty:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: registry
+    version: 9.0.1
+    integrity: sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: registry
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
+    dependencies: []
+  pipes:
+    type: registry
+    version: 8.0.0
+    integrity: sha256-kvfqGM4cPA/wCcBHbp5psouFw5dZGvku2462x7ZBwSY=
+    dependencies:
+      - aff
+      - lists
+      - mmorph
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+  prelude:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
+    dependencies: []
+  profunctor:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  quickcheck:
+    type: registry
+    version: 8.0.1
+    integrity: sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=
+    dependencies:
+      - arrays
+      - console
+      - control
+      - effect
+      - either
+      - enums
+      - exceptions
+      - foldable-traversable
+      - gen
+      - identity
+      - integers
+      - lazy
+      - lcg
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - numbers
+      - partial
+      - prelude
+      - record
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+  random:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=
+    dependencies:
+      - effect
+      - integers
+  record:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
+    dependencies:
+      - unsafe-coerce
+  spec:
+    type: registry
+    version: 7.3.0
+    integrity: sha256-YmmRmlHmSHyAM8j5/QVHLgkMhtAkt2FXytVb5j/Zu0s=
+    dependencies:
+      - aff
+      - ansi
+      - arrays
+      - avar
+      - bifunctors
+      - console
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - fork
+      - identity
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - now
+      - ordered-collections
+      - parallel
+      - pipes
+      - prelude
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+  spec-discovery:
+    type: registry
+    version: 8.0.1
+    integrity: sha256-Fr/b+oAsEvuAvvBqf7G5JCkhesuFnLIJa6PjlWqfp2g=
+    dependencies:
+      - aff
+      - aff-promise
+      - arrays
+      - console
+      - effect
+      - foldable-traversable
+      - node-fs
+      - prelude
+      - spec
+  spec-quickcheck:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-iE0iThqZCuDGe3pwg5RvqcL8E5cRQ4txDuloCclOsCs=
+    dependencies:
+      - aff
+      - prelude
+      - quickcheck
+      - random
+      - spec
+  st:
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
+    dependencies: []
+  unfoldable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
+    dependencies: []

--- a/nix/examples/simple-tested/spago.yaml
+++ b/nix/examples/simple-tested/spago.yaml
@@ -1,0 +1,14 @@
+package:
+  name: simple-tested
+  dependencies:
+    - prelude
+    - decimals
+  test:
+    dependencies:
+      - spec-discovery
+      - spec-quickcheck
+    main: Example.Simple.Tested.Tests
+workspace:
+  extra_packages: {}
+  package_set:
+    registry: 25.2.1

--- a/nix/examples/simple-tested/src/Main.purs
+++ b/nix/examples/simple-tested/src/Main.purs
@@ -1,0 +1,8 @@
+module Example.Simple.Tested where
+
+import Prelude
+
+import Data.Decimal (fromNumber, toNumber)
+
+roundTrip :: Number -> Number
+roundTrip = toNumber <<< fromNumber

--- a/nix/examples/simple-tested/test/DecimalsSpec.purs
+++ b/nix/examples/simple-tested/test/DecimalsSpec.purs
@@ -1,0 +1,14 @@
+module Example.Simple.Tested.Tests.Decimals where
+
+import Prelude
+
+import Example.Simple.Tested (roundTrip)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.QuickCheck (quickCheck)
+
+spec :: Spec Unit
+spec =
+  describe "decimals" do
+    describe "roundtrip" do
+      it "is identity"
+        $ quickCheck \n -> roundTrip n == n

--- a/nix/examples/simple-tested/test/Main.purs
+++ b/nix/examples/simple-tested/test/Main.purs
@@ -1,0 +1,14 @@
+module Example.Simple.Tested.Tests where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Aff (launchAff_)
+import Test.Spec.Discovery (discover)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner (runSpec)
+
+main :: Effect Unit
+main = launchAff_ do
+  specs <- discover """Example\.Simple\.Tested\.Tests\..*"""
+  runSpec [ consoleReporter ] specs

--- a/nix/examples/simple/default.nix
+++ b/nix/examples/simple/default.nix
@@ -12,7 +12,7 @@ in
     src = ./.;
     buildPhase = ''
       echo "Linking ..."
-      ln -s ${locked.jsArtifacts.simple}/output .
+      ln -s ${locked.simple}/output .
     '';
     installPhase = ''
       mkdir -p $out

--- a/overlay.nix
+++ b/overlay.nix
@@ -5,7 +5,7 @@ final: prev: let
   tooling = import ./manifests {inherit (prev) system lib callPackage stdenv;};
 
   # All of the library functions supported by this repo
-  buildSpagoLock = prev.callPackage ./nix/build-spago-lock.nix {inherit fromYAML;};
+  buildSpagoLock = final.callPackage ./nix/build-spago-lock.nix {inherit fromYAML;};
 
   purix = {
     buildSpagoLock = buildSpagoLock.buildSpagoLock;


### PR DESCRIPTION
This PR implements support for emulating `spago test` from nix's building environment. 

N.B. It's currently built on top of several other branches. It will be rebased and declared ready for a proper code review once those land. This PR is sent out to facilitate a concrete albeit preliminary discussion about alternatives.

The only relevant commit is ba1b2c12f5e33133d6be0cd2fc9e70e5195c5fd2. 

## Motivation

Being able to run an equivalent of `spago test` from within nix makes CI easy.
1. Writing CI pipelines is simplified because there is no need for special testing steps. They can just be part of a single `nix flake check`/`nix build .#my_website`. 
2. CIs are more reliable. The alternative of building with nix and testing separately is brittle because it's not clear that the artifacts/dependencies match in the two cases.

## Design

1. Compile the test modules in `checkPhase` of `buildSpagoLock` by invoking `purs`, similarly to how it's today invoked from `buildPhase`. This is the right place for it because the compilation cache is readily available. The nix package will refuse to build if tests fail.
2. Require user to explicitly turn on testing of the packages in their workspace by passing the names of those packages to `buildSpagoLock`. 
3. Rely on `slimlock` to build `npmDependencies` for testing. Expose them by changing the user-facing API of `buildSpagoLock` to return  `{ jsArtifacts, npmDependencies }`, where 
    - **jsArtifacts**: map from package names to derivations with `output/` directory. This is what `buildSpagoLock` returns today. 
    - **npmDependencies**: the output of `slimlock` ran on `$src/package-lock.json`. 

## Considerations 

- It's good to expose npmDependencies to the user, so that they can readily use them in the bundling step. This increases confidence that the node module used in tests and in the bundle are identical. 
- If the user doesn't reference `npmDependencies` and doesn't enable tests, they won't be built due to nix's laziness.
- OTOH, if they are to be built, the current implementation expects to find `slimlock` in scope, which requires the user to have installed it via overlay. This is to allow user not to depend on it, when it's not needed. 
- `super.callPackage` is changed to `self.callPackage` to allow the user to inject the `slimlock`. Seems correct to have it this way for other reasons too (e.g. allow user to override the node version), but I'm not 100% confident this won't lead to looping in some edge case.
- `Test.Main` is currently hardcoded as the main module of the test because we have no way of using `fromYAML` on `spago.yaml` (it may contain comments). `spago` could be modified to include this information in the `spago.lock`.

## Alternatives 

1. Instead of calling `slimlock` allow the user to pass in the node dependencies explicitly. 
    - Pros
       - More flexible for the user. 
       - Doesn't break the API. 
       - No confusion about errors stemming from `slimlock` missing from the overlays, when testing is enabled. 
    - Cons 
       - Requires more boilerplate. 
       - Possible source of bugs, if the node modules are built erroneously (e.g. node modules only relevant for the test dependencies are missing for some reason). This is a contrived point.
       - The exact directory of the node modules becomes magical and brittle: e.g. slimlock puts them into `js`, node2nix uses `lib`. 
2. Use `backend-optimizer`
    - Pros 
      - Faster tests
      - May uncover bugs in backend-optimizer (unlikely)
    - Cons
      - Slower builds
      - Complexity

