### PR TITLE
Add `--omit=optional` to spago build

### DIFF
--- a/manifests/build-support/mkDerivation.nix
+++ b/manifests/build-support/mkDerivation.nix
@@ -62,7 +62,7 @@ in
 
       npmDepsHash = source.depsHash;
 
-      nativeBuildInputs = [nodejs];
+      nativeBuildInputs = [nodejs] ++ lib.optionals (name == "spago") ([nodePackages.node-gyp python3] ++ lib.optionals stdenv.isDarwin [darwin.cctools]);
 
       # The prepack script runs the build script, but (so far) all derivations
       # are pre-built.

--- a/manifests/build-support/mkDerivation.nix
+++ b/manifests/build-support/mkDerivation.nix
@@ -62,14 +62,14 @@ in
 
       npmDepsHash = source.depsHash;
 
-      nativeBuildInputs = [nodejs] ++ lib.optionals (name == "spago") ([nodePackages.node-gyp python3] ++ lib.optionals stdenv.isDarwin [darwin.cctools]);
+      nativeBuildInputs = [nodejs];
 
       # The prepack script runs the build script, but (so far) all derivations
       # are pre-built.
       npmPackFlags = ["--ignore-scripts"];
       dontNpmBuild = true;
 
-      npmInstallFlags = ["--loglevel=verbose"];
+      npmInstallFlags = ["--loglevel=verbose"] ++ lib.optionals (name == "spago") ["--omit=optional"];
 
       meta = meta lib // {mainProgram = name;};
     }


### PR DESCRIPTION
`node-gyp` was failing to build `cpu-features` on x86 Darwin (due to some issue with `clang`, see below), which is an optional npm-wrapped native dependency of `ssh2`, but it is only used to set default ciphers which doesn't seem relevant.

This patch should make it into a pure node package. Although I still see `cpu-features` appearing on x86 Linux ...? No idea what's up with that, but at least it seems to build both places now.

<details>
<summary>Error logs</summary>

```
npm ERR! code 1
npm ERR! path /private/tmp/nix-build-spago-0.93.28.drv-0/package/node_modules/cpu-features
npm ERR! command failed
npm ERR! command sh -c node buildcheck.js > buildcheck.gypi && node-gyp rebuild
npm ERR! make: Entering directory '/private/tmp/nix-build-spago-0.93.28.drv-0/package/node_modules/cpu-features/build'
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_aarch64_linux_or_android.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_aarch64_macos_or_iphone.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_arm_linux_or_android.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_mips_linux_or_android.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_ppc_linux.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_x86_freebsd.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_x86_linux_or_android.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_x86_macos.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/impl_x86_windows.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/filesystem.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/stack_line_reader.o
npm ERR!   CC(target) Release/obj.target/cpu_features/deps/cpu_features/src/string_view.o
npm ERR!   LIBTOOL-STATIC Release/cpu_features.a
npm ERR!   CXX(target) Release/obj.target/cpufeatures/src/binding.o
npm ERR! make: Leaving directory '/private/tmp/nix-build-spago-0.93.28.drv-0/package/node_modules/cpu-features/build'
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@10.0.1
npm ERR! gyp info using node@20.11.1 | darwin | x64
npm ERR! gyp info find Python using Python version 3.11.8 found at "/nix/store/5w2l8qgsinw2gzlm2q61wychfvinsxvx-python3-3.11.8/bin/python3"
npm ERR! gyp WARN read config.gypi ENOENT: no such file or directory, open '/nix/store/656j4m7kj0rklasv69hx649p161zp5r3-nodejs-20.11.1-source/include/node/config.gypi'
npm ERR! gyp info spawn /nix/store/5w2l8qgsinw2gzlm2q61wychfvinsxvx-python3-3.11.8/bin/python3
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args '/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args 'binding.gyp',
npm ERR! gyp info spawn args '-f',
npm ERR! gyp info spawn args 'make',
npm ERR! gyp info spawn args '-I',
npm ERR! gyp info spawn args '/private/tmp/nix-build-spago-0.93.28.drv-0/package/node_modules/cpu-features/build/config.gypi',
npm ERR! gyp info spawn args '-I',
npm ERR! gyp info spawn args '/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args '-I',
npm ERR! gyp info spawn args '/nix/store/656j4m7kj0rklasv69hx649p161zp5r3-nodejs-20.11.1-source/common.gypi',
npm ERR! gyp info spawn args '-Dlibrary=shared_library',
npm ERR! gyp info spawn args '-Dvisibility=default',
npm ERR! gyp info spawn args '-Dnode_root_dir=/nix/store/656j4m7kj0rklasv69hx649p161zp5r3-nodejs-20.11.1-source',
npm ERR! gyp info spawn args '-Dnode_gyp_dir=/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1/lib/node_modules/npm/node_modules/node-gyp',
npm ERR! gyp info spawn args '-Dnode_lib_file=/nix/store/656j4m7kj0rklasv69hx649p161zp5r3-nodejs-20.11.1-source/$(Configuration)/node.lib',
npm ERR! gyp info spawn args '-Dmodule_root_dir=/private/tmp/nix-build-spago-0.93.28.drv-0/package/node_modules/cpu-features',
npm ERR! gyp info spawn args '-Dnode_engine=v8',
npm ERR! gyp info spawn args '--depth=.',
npm ERR! gyp info spawn args '--no-parallel',
npm ERR! gyp info spawn args '--generator-output',
npm ERR! gyp info spawn args 'build',
npm ERR! gyp info spawn args '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! In file included from ../src/binding.cc:1:
npm ERR! In file included from /nix/store/656j4m7kj0rklasv69hx649p161zp5r3-nodejs-20.11.1-source/src/node.h:73:
npm ERR! In file included from /nix/store/656j4m7kj0rklasv69hx649p161zp5r3-nodejs-20.11.1-source/deps/v8/include/v8.h:21:
npm ERR! In file included from /nix/store/33f0vanq37w3c6p0387fwqpc8qgcnjpv-libcxx-16.0.6-dev/include/c++/v1/memory:884:
npm ERR! In file included from /nix/store/33f0vanq37w3c6p0387fwqpc8qgcnjpv-libcxx-16.0.6-dev/include/c++/v1/__memory/allocate_at_least.h:13:
npm ERR! In file included from /nix/store/33f0vanq37w3c6p0387fwqpc8qgcnjpv-libcxx-16.0.6-dev/include/c++/v1/__memory/allocator_traits.h:14:
npm ERR! In file included from /nix/store/33f0vanq37w3c6p0387fwqpc8qgcnjpv-libcxx-16.0.6-dev/include/c++/v1/__memory/construct_at.h:23:
npm ERR! /nix/store/33f0vanq37w3c6p0387fwqpc8qgcnjpv-libcxx-16.0.6-dev/include/c++/v1/new:355:14: error: no member named 'aligned_alloc' in the global namespace
npm ERR!     return ::aligned_alloc(__alignment, __size > __rounded_size ? __size : __rounded_size);
npm ERR!            ~~^
npm ERR! 1 error generated.
npm ERR! make: *** [cpufeatures.target.mk:133: Release/obj.target/cpufeatures/src/binding.o] Error 1
npm ERR! gyp ERR! build error 
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack at ChildProcess.<anonymous> (/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:209:23)
npm ERR! gyp ERR! System Darwin 21.6.0
npm ERR! gyp ERR! command "/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1/bin/node" "/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /private/tmp/nix-build-spago-0.93.28.drv-0/package/node_modules/cpu-features
npm ERR! gyp ERR! node -v v20.11.1
npm ERR! gyp ERR! node-gyp -v v10.0.1
npm ERR! gyp ERR! not ok
```

</details>